### PR TITLE
fix: lowercase Docker tag in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   IMAGE_NAME: lan-transcriber
+  IMAGE_REGISTRY: ghcr.io
+  IMAGE_OWNER: ${{ github.repository_owner }}
+  IMAGE_TAG: latest
 
 jobs:
   lint-and-test:
@@ -47,11 +50,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Normalise owner to lower-case
+        id: vars
+        run: echo "OWNER_LC=${IMAGE_OWNER,,}" >> "$GITHUB_ENV"
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ env.OWNER_LC }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push Docker image
@@ -59,4 +66,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.IMAGE_REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
## Summary
- use lower case repo name in Docker build job
- generalize registry, owner, and tag variables for easier reuse

## Testing
- `CI=true pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cd4cb93ec83339cfd3ac86cd41ab4