### PR TITLE
Fix torch pins for WhisperX

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-torch==2.2.2+cpu
-torchvision==0.17.2+cpu
-torchaudio==2.2.2+cpu
+torch==2.5.1+cpu
+torchvision==0.18.1+cpu
+torchaudio==2.5.1+cpu
 
 whisperx==3.4.2
 faster-whisper==1.1.1


### PR DESCRIPTION
## Summary
- update torch/vision/audio CPU pins to v2.5.1 series

## Testing
- `python -m pip install -r ci-requirements.txt`
- `CI=true pytest -q`
- `python -m pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686cde43f49c8333aeed2556300d74d4