### PR TITLE
Fix torchvision version for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
 
 COPY web_transcribe.py .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 torch==2.5.1+cpu
-torchvision==0.18.1+cpu
+torchvision==0.20.0+cpu   # ← supports torch 2.5.x
 torchaudio==2.5.1+cpu
 
 whisperx==3.4.2


### PR DESCRIPTION
## Summary
- align torchvision with torch in `requirements.txt`
- use PyTorch CPU index when installing in Dockerfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch==2.5.1+cpu)*

------
https://chatgpt.com/codex/tasks/task_e_686ce09177e08333975856059dd37966