### PR TITLE
Fix docker workflow syntax error

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Normalise owner to lower-case
         id: vars
-        run: echo "OWNER_LC=${{ github.repository_owner,, }}" >> "$GITHUB_ENV"
+        run: echo "OWNER_LC=${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]' >> "$GITHUB_ENV"
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- fix syntax error in owner normalisation step

## Testing
- `CI=true pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7958626c8333b51bc2f37d72a85d