### PR TITLE
Fix GHCR login in Docker workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -12,9 +12,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - name: Normalise owner to lower-case
-        id: vars
-        run: echo "OWNER_LC=${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]' >> "$GITHUB_ENV"
+      - name: Set lowercase owner
+        run: echo "OWNER_LC=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -26,4 +25,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/lan-transcriber:latest
+          tags: ghcr.io/${{ env.OWNER_LC }}/lan-transcriber:latest


### PR DESCRIPTION
## Summary
- fix lowercasing step so OWNER_LC env is usable
- use OWNER_LC for login and image tagging

## Testing
- `CI=true pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d7b8e76748333a955300533f89e8e