### PR TITLE
Fix Docker/CI build: align torch 2.5.1+cpu with whisperx

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -21,9 +21,10 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('ci-requirements.txt') }}
           restore-keys: ${{ runner.os }}-pip-
-      - name: Install test deps
-        run: pip install -r ci-requirements.txt
+      - name: Install deps
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -r ci-requirements.txt
       - name: Run tests
-        env:
-          CI: "true"
         run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-torch==2.5.0+cpu
-torchvision==0.20.0+cpu      # matches torch 2.5.0
-torchaudio==2.5.0+cpu
+torch==2.5.1+cpu
+torchvision==0.20.1+cpu      # version that matches torch 2.5.1
+torchaudio==2.5.1+cpu
 
 whisperx==3.4.2
 faster-whisper==1.1.1

--- a/web_transcribe.py
+++ b/web_transcribe.py
@@ -1,53 +1,5 @@
 #!/usr/bin/env python3
-# CI stub: fake heavy libs when CI=true so tests can import
-import os, sys, types
-if os.getenv("CI") == "true":
-    def _fake(mod):
-        sys.modules[mod] = types.ModuleType(mod)
-    for m in (
-        "torch", "torchvision", "torchaudio",
-        "faster_whisper", "pyannote", "pyannote.audio",
-        "gradio", "numpy",
-    ):
-        _fake(m)
-
-if os.getenv("CI") == "true":  # running on GitHub Actions
-    class _Dummy:
-        def __init__(self, *a, **k):
-            pass
-
-        def __call__(self, *a, **k):
-            return _Dummy()
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def __getattr__(self, name):
-            return _Dummy()
-
-    class _Stub(types.ModuleType):
-        def __getattr__(self, name):
-            return _Dummy()
-
-    import importlib.machinery
-
-    def _fake(mod, **attrs):
-        stub = _Stub(mod)
-        stub.__dict__.update(attrs)
-        stub.__path__ = []
-        stub.__spec__ = importlib.machinery.ModuleSpec(mod, stub, is_package=True)
-        sys.modules[mod] = stub
-    for name in (
-        "torch", "torchvision", "torchaudio",
-        "numpy", "gradio", "faster_whisper",
-        "pyannote", "pyannote.audio", "pyannote.pipeline",
-        "pyannote.audio.utils", "pyannote.audio.utils.signal",
-        "ollama", "transformers",
-    ):
-        _fake(name, __version__="0.0.0-stub")
+import sys
 # ────────────────────────────────────────────────────────────────────────
 # LAN Recording-Transcriber
 #  * faster-whisper large-v3  (ASR)


### PR DESCRIPTION
## Summary
- update CPU torch pins in `requirements.txt`
- uninstall CI stub injection for heavy libs
- install real dependencies in tests

## Testing
- `pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu` *(fails: No matching distribution found)*
- `pytest -q tests/test_imports.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_686d7e465fc883338e596a2da916db2c