### PR TITLE
Fix deploy SSH setup

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -7,23 +7,66 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check secrets
+        if: >-
+          ${{
+            secrets.STAGING_HOST == '' ||
+            secrets.STAGING_USER == '' ||
+            secrets.STAGING_SSH_KEY == ''
+          }}
+        run: |
+          echo "Skipping staging deploy – secrets missing"
+          exit 0
+
+      - name: Setup known_hosts
+        if: >-
+          ${{
+            secrets.STAGING_HOST != '' &&
+            secrets.STAGING_USER != '' &&
+            secrets.STAGING_SSH_KEY != ''
+          }}
+        run: ssh-keyscan -H ${{ secrets.STAGING_HOST }} >> ~/.ssh/known_hosts
+
       - name: Copy compose to VPS
-        uses: appleboy/scp-action@v0.1.4
+        if: >-
+          ${{
+            secrets.STAGING_HOST != '' &&
+            secrets.STAGING_USER != '' &&
+            secrets.STAGING_SSH_KEY != ''
+          }}
+        uses: appleboy/scp-action@v1.0.0
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           source: "infra/staging/*"
           target: "~/lan-staging"
+          strip_components: 2
+
       - name: Up containers
-        uses: appleboy/ssh-action@v0.1.4
+        if: >-
+          ${{
+            secrets.STAGING_HOST != '' &&
+            secrets.STAGING_USER != '' &&
+            secrets.STAGING_SSH_KEY != ''
+          }}
+        uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           script: |
+            set -e
             cd ~/lan-staging
             docker compose pull || true
             docker compose up -d --build
+
       - name: Smoke test
+        if: >-
+          ${{
+            secrets.STAGING_HOST != '' &&
+            secrets.STAGING_USER != '' &&
+            secrets.STAGING_SSH_KEY != ''
+          }}
         run: python scripts/smoke_test.py --base-url http://${{ secrets.STAGING_HOST }}:7860 --file tests/fixtures/1_EN.mp3.b64

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ docker compose up -d --build
 
 The stack exposes `lan_transcriber_health{env="staging"}` on `/metrics` for
 future monitoring.
+
+## Staging deploy secrets
+
+| Secret | Description | Example |
+|--------|-------------|---------|
+| STAGING_HOST | VPS public IP / DNS | 203.0.113.10 |
+| STAGING_USER | SSH user | ubuntu |
+| STAGING_SSH_KEY | private key PEM (no passphrase) | multiline |


### PR DESCRIPTION
## Summary
- fix workflow secret guard to skip if missing
- update deploy SSH and SCP actions
- document required secrets

## Testing
- `yamllint .github/workflows/staging-deploy.yml`
- ❌ `act -j staging-deploy` *(fails: no Docker service)*
- ❌ `pip install ...` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687e9d4194a48333806bcc482d30f29b