### PR TITLE
Fix staging deploy secret check

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -4,9 +4,19 @@ on:
     branches: [main]
 jobs:
   deploy:
-    if: ${{ secrets.STAGING_HOST != '' && secrets.STAGING_USER != '' && secrets.STAGING_SSH_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check required secrets
+        env:
+          STAGING_HOST: ${{ secrets.STAGING_HOST }}
+          STAGING_USER: ${{ secrets.STAGING_USER }}
+          STAGING_SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
+        run: |
+          if [ -z "$STAGING_HOST" ] || [ -z "$STAGING_USER" ] || [ -z "$STAGING_SSH_KEY" ]; then
+            echo "::error::Missing required secrets STAGING_HOST, STAGING_USER, and STAGING_SSH_KEY"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Setup known_hosts


### PR DESCRIPTION
## Summary
- fix `staging-deploy.yml` by removing invalid job-level secret check
- add step that fails early if any required staging secret is missing

## Testing
- `pip install --require-hashes -r ci-requirements.txt -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f634ae32c833399d892e2a3569c21