### PR TITLE
Fix HF model cache path in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ docker compose pull
 docker compose up -d --build
 ```
 
+The compose file mounts `/opt/lan_cache/hf` into `/root/.cache/huggingface` so
+models are cached across runs.
+
 `docker-compose.yml` expects a `.env` file with the following variables:
 
 | Variable | Description |

--- a/infra/staging/docker-compose.yml
+++ b/infra/staging/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - LLM_BASE_URL=http://llm:8000
     volumes:
       - lan_cache:/root/.cache
+      - /opt/lan_cache/hf:/root/.cache/huggingface
     networks:
       - lan_net
 


### PR DESCRIPTION
## Summary
- mount persistent cache for WhisperX models in docker-compose
- document HF cache volume mount

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f810e429c8333bd701abe2c51588a