### PR TITLE
Make staging deploy workflow CI friendly

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -6,11 +6,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Populate staging environment variables
+        run: |
+          echo "STAGING_HOST=${STAGING_HOST:-${{ secrets.STAGING_HOST }}}" >> "$GITHUB_ENV"
+          echo "STAGING_USER=${STAGING_USER:-${{ secrets.STAGING_USER }}}" >> "$GITHUB_ENV"
+          echo "STAGING_SSH_KEY=${STAGING_SSH_KEY:-${{ secrets.STAGING_SSH_KEY }}}" >> "$GITHUB_ENV"
+
       - name: Check required secrets
-        env:
-          STAGING_HOST: ${{ secrets.STAGING_HOST }}
-          STAGING_USER: ${{ secrets.STAGING_USER }}
-          STAGING_SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
         run: |
           if [ -z "$STAGING_HOST" ] || [ -z "$STAGING_USER" ] || [ -z "$STAGING_SSH_KEY" ]; then
             echo "::error::Missing required secrets STAGING_HOST, STAGING_USER, and STAGING_SSH_KEY"
@@ -20,14 +22,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup known_hosts
-        run: ssh-keyscan -H ${{ secrets.STAGING_HOST }} >> ~/.ssh/known_hosts
+        run: ssh-keyscan -H "$STAGING_HOST" >> ~/.ssh/known_hosts
 
       - name: Copy compose to VPS
         uses: appleboy/scp-action@v1.0.0
         with:
-          host: ${{ secrets.STAGING_HOST }}
-          username: ${{ secrets.STAGING_USER }}
-          key: ${{ secrets.STAGING_SSH_KEY }}
+          host: ${{ env.STAGING_HOST }}
+          username: ${{ env.STAGING_USER }}
+          key: ${{ env.STAGING_SSH_KEY }}
           source: "infra/staging/*"
           target: "~/lan-staging"
           strip_components: 2
@@ -35,9 +37,9 @@ jobs:
       - name: Up containers
         uses: appleboy/ssh-action@v1.0.0
         with:
-          host: ${{ secrets.STAGING_HOST }}
-          username: ${{ secrets.STAGING_USER }}
-          key: ${{ secrets.STAGING_SSH_KEY }}
+          host: ${{ env.STAGING_HOST }}
+          username: ${{ env.STAGING_USER }}
+          key: ${{ env.STAGING_SSH_KEY }}
           script: |
             set -e
             cd ~/lan-staging
@@ -45,4 +47,4 @@ jobs:
             docker compose up -d --build
 
       - name: Smoke test
-        run: python scripts/smoke_test.py --base-url http://${{ secrets.STAGING_HOST }}:7860 --file tests/fixtures/1_EN.mp3.b64
+        run: python scripts/smoke_test.py --base-url http://$STAGING_HOST:7860 --file tests/fixtures/1_EN.mp3.b64


### PR DESCRIPTION
## Summary
- adjust `staging-deploy.yml` so missing secrets fail early
- allow fake secrets via environment variables
- switch deployment steps to read env vars instead of secrets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9d0e8abc8333b24992baf6d4fddd