### PR TITLE
Fix staging deploy workflow CI ssh logic

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -31,6 +31,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Ensure SSH folder
+        if: env.CI != 'true'
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+
       - name: Setup known_hosts
         if: env.CI != 'true'
         run: ssh-keyscan -H "$STAGING_HOST" >> ~/.ssh/known_hosts


### PR DESCRIPTION
## Summary
- ensure `.ssh` exists before populating known_hosts
- skip SSH-related steps in CI

## Testing
- `pytest -q`
- `act -j deploy -W .github/workflows/staging-deploy.yml --list`


------
https://chatgpt.com/codex/tasks/task_e_68829d8f3c348333a98fd56fb61e92aa