### PR TITLE
Update Gradio usage for 4.x compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -664,10 +664,7 @@ fsspec[http]==2025.7.0 \
     #   lightning
     #   pytorch-lightning
     #   torch
-gradio==5.35.0 \
-    --hash=sha256:781a80df25355861e44fd2819fac4ed43cf08ea77911570fb0682f6ae16b9c7c \
-    --hash=sha256:f3e68ab02cfe0d9f364068883c8caf30b5b6fb62c10a19ccea3583a0c2e50acd
-    # via -r requirements.in
+gradio>=4.29.0,<5.0.0
 gradio-client==1.10.4 \
     --hash=sha256:271018368f4f0a2d2dfb943bbd495277518172be50e44f54d99c62fa5533ae09 \
     --hash=sha256:5dd0ff615f859b8d9fd3ce88555278e3d48bb6ffef79eb956a01e132edbcc1b0

--- a/web_transcribe.py
+++ b/web_transcribe.py
@@ -104,7 +104,10 @@ def enroll_speaker(voice_path: str, name: str):
     return gr.Success(f"Speaker **{name}** added. You can re-run transcription.")
 
 
-with gr.Blocks(title="LAN Recording-Transcriber") as demo:  # pragma: no cover - UI glue
+with gr.Blocks(
+    title="LAN Recording-Transcriber",
+    css=".scroll {max-height: 65vh; overflow-y: auto;}",
+) as demo:  # pragma: no cover - UI glue
     gr.Markdown(
         "## LAN Recording-Transcriber  \n_Offline: WhisperX · pyannote · external LLM_"
     )
@@ -136,6 +139,6 @@ with gr.Blocks(title="LAN Recording-Transcriber") as demo:  # pragma: no cover -
     )
     add_btn.click(enroll_speaker, inputs=[new_voice, new_name], outputs=add_out)
 
-    demo.load(lambda: None, js="", css=".scroll {max-height: 65vh; overflow-y: auto;}")
+    demo.load(lambda: None)
 
     demo.launch(server_name="0.0.0.0", server_port=7860, share=False)


### PR DESCRIPTION
## Summary
- pin Gradio to a 4.x-compatible version range
- construct Blocks with CSS in the constructor and update `.load()` usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e836bad48333be5986689eee64d1