### PR TITLE
Fix Gradio startup issues

### DIFF
--- a/lan_transcriber/api.py
+++ b/lan_transcriber/api.py
@@ -18,6 +18,12 @@ _subscribers: List[asyncio.Queue[str]] = []
 _current_result: TranscriptResult | None = None
 
 
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    """Simple health check used by monitoring."""
+    return {"status": "ok"}
+
+
 @app.on_event("startup")
 async def _start_metrics() -> None:
     asyncio.create_task(write_metrics_snapshot(Path("metrics.snap")))
@@ -65,4 +71,4 @@ def set_current_result(result: TranscriptResult | None) -> None:
     _current_result = result
 
 
-__all__ = ["app", "set_current_result"]
+__all__ = ["app", "set_current_result", "healthz"]

--- a/web_transcribe.py
+++ b/web_transcribe.py
@@ -141,4 +141,4 @@ with gr.Blocks(
 
     demo.load(lambda: None)
 
-    demo.launch(server_name="0.0.0.0", server_port=7860, share=False)
+    demo.launch()


### PR DESCRIPTION
## Summary
- provide a simple `/healthz` endpoint instead of returning boolean
- default to `demo.launch()` to avoid Gradio share check errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688433ab2c288333882eb08361bd7a05