### PR TITLE
Fix enroll_speaker return type

### DIFF
--- a/web_transcribe.py
+++ b/web_transcribe.py
@@ -95,13 +95,13 @@ async def transcribe_and_summarize(text: str) -> tuple[Path, Path]:
 def enroll_speaker(voice_path: str, name: str):
     """Dummy implementation kept for UI compatibility."""
     if not voice_path or not name:
-        return gr.Info("Upload voice sample AND type the name first.")
+        return "⚠️ Upload voice sample AND type the name first."
     cfg = pipeline.Settings()
     cfg.voices_dir.mkdir(exist_ok=True)
     import shutil
 
     shutil.copy(voice_path, cfg.voices_dir / f"{name}.wav")
-    return gr.Success(f"Speaker **{name}** added. You can re-run transcription.")
+    return f"✅ Speaker **{name}** added. You can re-run transcription."
 
 
 with gr.Blocks(


### PR DESCRIPTION
## Summary
- return regular strings in `enroll_speaker` instead of Gradio wrapper objects

## Testing
- `CI=true pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d27f4e7c83339f6a2eb75e8b8a08