### PR TITLE
Fix Gradio load callback and Clear button

### DIFF
--- a/web_transcribe.py
+++ b/web_transcribe.py
@@ -138,10 +138,12 @@ with gr.Blocks(
         outputs=[out_md, out_full, file_sum, file_md, unknown, out_voice],
     )
     btn_clear.click(
-        lambda: (None,) * 5, None, [audio_in, out_md, out_full, file_sum, file_md]
+        lambda: (None,) * 6,
+        None,
+        [audio_in, out_md, out_full, file_sum, file_md, out_voice],
     )
     add_btn.click(enroll_speaker, inputs=[new_voice, new_name], outputs=add_out)
 
-    demo.load(lambda: None)
+    demo.load(lambda: "ready")
 
     demo.launch()


### PR DESCRIPTION
## Summary
- ensure UI load callback returns a string
- reset all six outputs when clearing

## Testing
- `CI=true pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885198351688333acc1ced86fb6d87d