### PR TITLE
PR-DIARIZATION-FLICKER-01: filter flickering diarization speakers

### DIFF
--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -6,31 +6,31 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [  6%]
 ........................................................................ [ 13%]
 ........................................................................ [ 20%]
-........................................................................ [ 27%]
+........................................................................ [ 26%]
 ........................................................................ [ 33%]
 ........................................................................ [ 40%]
 ........................................................................ [ 47%]
-........................................................................ [ 54%]
+........................................................................ [ 53%]
 ........................................................................ [ 60%]
 ........................................................................ [ 67%]
-........................................................................ [ 74%]
-..............................s......................................... [ 81%]
+........................................................................ [ 73%]
+.....................................s.................................. [ 80%]
 ........................................................................ [ 87%]
 ........................................................................ [ 94%]
-.........................................................                [100%]
+................................................................         [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
     import audioop
 
-lan_transcriber/pipeline_steps/orchestrator.py:247
+lan_transcriber/pipeline_steps/orchestrator.py:250
 tests/test_imports.py::test_imports[lan_transcriber.pipeline_steps.orchestrator]
 tests/test_imports.py::test_orchestrator_import_does_not_import_whisperx
-  /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/orchestrator.py:247: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
+  /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/orchestrator.py:250: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
     class Settings(BaseSettings):
 
-lan_app/config.py:47
-  /home/alexey/LAN_Transcriber/lan_app/config.py:47: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
+lan_app/config.py:49
+  /home/alexey/LAN_Transcriber/lan_app/config.py:49: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
     class AppSettings(BaseSettings):
 
 tests/test_cov_lan_app_health_worker.py::test_healthchecks_module_main_guard
@@ -56,13 +56,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.11.9-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   13990      0   4650      0   100%
+TOTAL   14074      0   4684      0   100%
 
 63 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1064 passed, 3 skipped, 11 warnings in 94.39s (0:01:34)
+1071 passed, 3 skipped, 11 warnings in 96.67s (0:01:36)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -82,10 +82,10 @@ lan_transcriber/normalizer.py                              25      0     14     
 lan_transcriber/pipeline.py                                 5      0      0      0   100%
 lan_transcriber/pipeline_steps/__init__.py                  7      0      0      0   100%
 lan_transcriber/pipeline_steps/artifacts.py                19      0      0      0   100%
-lan_transcriber/pipeline_steps/diarization_quality.py     268      0     98      0   100%
+lan_transcriber/pipeline_steps/diarization_quality.py     318      0    120      0   100%
 lan_transcriber/pipeline_steps/language.py                155      0     64      0   100%
 lan_transcriber/pipeline_steps/multilingual_asr.py        239      0     88      0   100%
-lan_transcriber/pipeline_steps/orchestrator.py           1173      0    334      0   100%
+lan_transcriber/pipeline_steps/orchestrator.py           1190      0    340      0   100%
 lan_transcriber/pipeline_steps/precheck.py                116      0     46      0   100%
 lan_transcriber/pipeline_steps/snippets.py                231      0     84      0   100%
 lan_transcriber/pipeline_steps/speaker_turns.py           240      0    116      0   100%
@@ -94,7 +94,7 @@ lan_transcriber/runtime_paths.py                           21      0      4     
 lan_transcriber/torch_safe_globals.py                     126      0     40      0   100%
 lan_transcriber/utils.py                                   50      0     30      0   100%
 -----------------------------------------------------------------------------------------
-TOTAL                                                    4118      0   1374      0   100%
+TOTAL                                                    4185      0   1402      0   100%
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%
@@ -105,7 +105,7 @@ lan_app/calendar/__init__.py           4      0      0      0   100%
 lan_app/calendar/ics.py              235      0     88      0   100%
 lan_app/calendar/matching.py         333      0    132      0   100%
 lan_app/calendar/service.py           66      0     12      0   100%
-lan_app/config.py                    110      0     16      0   100%
+lan_app/config.py                    112      0     16      0   100%
 lan_app/constants.py                  30      0      0      0   100%
 lan_app/conversation_metrics.py      380      0    150      0   100%
 lan_app/db.py                       1434      0    318      0   100%
@@ -130,7 +130,7 @@ lan_app/ui.py                         59      0     10      0   100%
 lan_app/ui_routes.py                2572      0    988      0   100%
 lan_app/uploads.py                    79      0     14      0   100%
 lan_app/worker.py                     28      0      2      0   100%
-lan_app/worker_tasks.py             1695      0    490      0   100%
+lan_app/worker_tasks.py             1710      0    496      0   100%
 lan_app/workers.py                    10      0      0      0   100%
 --------------------------------------------------------------------
-TOTAL                               9872      0   3276      0   100%
+TOTAL                               9889      0   3282      0   100%

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,204 +1,580 @@
 diff --git a/lan_app/config.py b/lan_app/config.py
-index 0b31487..d5b4bfe 100644
+index d5b4bfe..2bb2b4d 100644
 --- a/lan_app/config.py
 +++ b/lan_app/config.py
-@@ -18,6 +18,7 @@ from lan_transcriber.pipeline_steps.diarization_quality import (
- from lan_transcriber.pipeline_steps.speaker_turns import (
-     DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,
-     DEFAULT_SPEAKER_TURN_MIN_WORDS,
-+    DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC,
+@@ -12,6 +12,8 @@ from lan_app.constants import DEFAULT_RQ_QUEUE_NAME
+ from lan_transcriber.pipeline_steps.diarization_quality import (
+     DEFAULT_DIALOG_RETRY_MIN_DURATION_SECONDS,
+     DEFAULT_DIALOG_RETRY_MIN_TURNS,
++    DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
++    DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
+     DEFAULT_DIARIZATION_MERGE_GAP_SECONDS,
+     DEFAULT_DIARIZATION_MIN_TURN_SECONDS,
  )
- from lan_transcriber.runtime_paths import default_data_root, default_recordings_root
- 
-@@ -326,6 +327,14 @@ class AppSettings(BaseSettings):
-             "SPEAKER_TURN_MERGE_GAP_SEC",
-         ),
+@@ -319,6 +321,22 @@ class AppSettings(BaseSettings):
+         default=DEFAULT_DIARIZATION_MIN_TURN_SECONDS,
+         ge=0.0,
      )
-+    speaker_turn_short_merge_gap_sec: float = Field(
-+        default=DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC,
++    diarization_flicker_min_seconds: float = Field(
++        default=DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
 +        ge=0.0,
 +        validation_alias=AliasChoices(
-+            "LAN_SPEAKER_TURN_SHORT_MERGE_GAP_SEC",
-+            "SPEAKER_TURN_SHORT_MERGE_GAP_SEC",
++            "LAN_DIARIZATION_FLICKER_MIN_SECONDS",
++            "DIARIZATION_FLICKER_MIN_SECONDS",
 +        ),
 +    )
-     speaker_turn_min_words: int = Field(
-         default=DEFAULT_SPEAKER_TURN_MIN_WORDS,
-         ge=0,
++    diarization_flicker_max_consecutive: int = Field(
++        default=DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
++        ge=0,
++        validation_alias=AliasChoices(
++            "LAN_DIARIZATION_FLICKER_MAX_CONSECUTIVE",
++            "DIARIZATION_FLICKER_MAX_CONSECUTIVE",
++        ),
++    )
+     speaker_turn_merge_gap_sec: float = Field(
+         default=DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,
+         ge=0.0,
 diff --git a/lan_app/worker_tasks.py b/lan_app/worker_tasks.py
-index 258e32a..b86c618 100644
+index b86c618..7757728 100644
 --- a/lan_app/worker_tasks.py
 +++ b/lan_app/worker_tasks.py
-@@ -1883,6 +1883,7 @@ def _build_pipeline_settings(settings: AppSettings) -> PipelineSettings:
+@@ -44,6 +44,7 @@ from lan_transcriber.pipeline_steps.diarization_quality import (
+     DEFAULT_DIALOG_RETRY_MIN_TURNS,
+     SpeakerTurnSmoothingResult,
+     annotation_speaker_count,
++    filter_flickering_speakers,
+     profile_default_speaker_hints,
+     smooth_speaker_turns,
+ )
+@@ -1882,6 +1883,8 @@ def _build_pipeline_settings(settings: AppSettings) -> PipelineSettings:
+         diarization_dialog_retry_min_turns=settings.diarization_dialog_retry_min_turns,
          diarization_merge_gap_seconds=settings.diarization_merge_gap_seconds,
          diarization_min_turn_seconds=settings.diarization_min_turn_seconds,
++        diarization_flicker_min_seconds=settings.diarization_flicker_min_seconds,
++        diarization_flicker_max_consecutive=settings.diarization_flicker_max_consecutive,
          speaker_turn_merge_gap_sec=settings.speaker_turn_merge_gap_sec,
-+        speaker_turn_short_merge_gap_sec=settings.speaker_turn_short_merge_gap_sec,
+         speaker_turn_short_merge_gap_sec=settings.speaker_turn_short_merge_gap_sec,
          speaker_turn_min_words=settings.speaker_turn_min_words,
-         vad_method=settings.vad_method,
+@@ -2940,6 +2943,42 @@ def _stage_speaker_turns(ctx: _PipelineExecutionContext) -> _StageResult:
+     detected_language = normalise_language_code(
+         (ctx.language_payload.get("language") or {}).get("detected")
      )
-@@ -2950,7 +2951,7 @@ def _stage_speaker_turns(ctx: _PipelineExecutionContext) -> _StageResult:
-     unsmoothed_speaker_turns = merge_short_turns(
-         unsmoothed_speaker_turns,
-         min_words=ctx.pipeline_settings.speaker_turn_min_words,
--        merge_gap_sec=ctx.pipeline_settings.speaker_turn_merge_gap_sec,
-+        merge_gap_sec=ctx.pipeline_settings.speaker_turn_short_merge_gap_sec,
-     )
-     diariser_mode = str(ctx.diarization_runtime.get("mode") or "unknown").strip().lower()
-     if diariser_mode == "pyannote" and not ctx.diarization_runtime.get("used_dummy_fallback"):
-diff --git a/lan_transcriber/pipeline_steps/orchestrator.py b/lan_transcriber/pipeline_steps/orchestrator.py
-index 9650e1d..105f1c9 100644
---- a/lan_transcriber/pipeline_steps/orchestrator.py
-+++ b/lan_transcriber/pipeline_steps/orchestrator.py
-@@ -74,6 +74,7 @@ from .snippets import SnippetExportRequest, export_speaker_snippets, write_empty
- from .speaker_turns import (
-     DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,
-     DEFAULT_SPEAKER_TURN_MIN_WORDS,
-+    DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC,
-     _diarization_segments,
-     build_speaker_turns,
-     merge_short_turns,
-@@ -399,6 +400,15 @@ class Settings(BaseSettings):
-             "LAN_SPEAKER_TURN_MERGE_GAP_SEC",
-         ),
-     )
-+    speaker_turn_short_merge_gap_sec: float = Field(
-+        default=DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC,
-+        ge=0.0,
-+        validation_alias=AliasChoices(
-+            "speaker_turn_short_merge_gap_sec",
-+            "SPEAKER_TURN_SHORT_MERGE_GAP_SEC",
-+            "LAN_SPEAKER_TURN_SHORT_MERGE_GAP_SEC",
++    diarization_segments_before_flicker = sorted(
++        ctx.diarization_segments,
++        key=lambda row: (
++            safe_float(row.get("start"), default=0.0),
++            safe_float(row.get("end"), default=0.0),
++            str(row.get("speaker") or ""),
 +        ),
 +    )
-     speaker_turn_min_words: int = Field(
-         default=DEFAULT_SPEAKER_TURN_MIN_WORDS,
-         ge=0,
-@@ -2822,7 +2832,7 @@ async def run_pipeline(
-         unsmoothed_speaker_turns = merge_short_turns(
-             unsmoothed_speaker_turns,
-             min_words=cfg.speaker_turn_min_words,
--            merge_gap_sec=cfg.speaker_turn_merge_gap_sec,
-+            merge_gap_sec=cfg.speaker_turn_short_merge_gap_sec,
-         )
-         diariser_mode = _diariser_mode(diariser)
-         if diariser_mode == "pyannote" and not used_dummy_fallback:
-diff --git a/lan_transcriber/pipeline_steps/speaker_turns.py b/lan_transcriber/pipeline_steps/speaker_turns.py
-index 3ca6e8f..fb7f5ae 100644
---- a/lan_transcriber/pipeline_steps/speaker_turns.py
-+++ b/lan_transcriber/pipeline_steps/speaker_turns.py
-@@ -7,6 +7,15 @@ from lan_transcriber.utils import normalise_language_code, safe_float
- DEFAULT_INTERRUPTION_OVERLAP_SEC = 0.3
- DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC = 4.0
- DEFAULT_SPEAKER_TURN_MIN_WORDS = 6
-+# The post-pass that folds short turns into adjacent same-speaker turns must
-+# use a strictly larger gap than DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC. By the
-+# time merge_short_turns runs, build_speaker_turns has already collapsed every
-+# adjacent same-speaker pair whose gap is <= DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,
-+# so any same-speaker neighbours that remain have gaps strictly above that
-+# threshold. A larger threshold here lets the short-turn pass actually fire
-+# for brief interjections (e.g. "uh-huh", "yeah okay") that sit between
-+# longer same-speaker stretches separated by a noticeable silence.
-+DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC = 8.0
++    ctx.diarization_segments = filter_flickering_speakers(
++        diarization_segments_before_flicker,
++        min_total_seconds=ctx.pipeline_settings.diarization_flicker_min_seconds,
++        max_consecutive_segments=ctx.pipeline_settings.diarization_flicker_max_consecutive,
++    )
++    flicker_stats: dict[str, dict[str, float]] = {}
++    for before_row, after_row in zip(
++        diarization_segments_before_flicker, ctx.diarization_segments
++    ):
++        before_speaker = str(before_row.get("speaker") or "")
++        after_speaker = str(after_row.get("speaker") or "")
++        if before_speaker == after_speaker:
++            continue
++        stats = flicker_stats.setdefault(
++            before_speaker,
++            {"segments": 0.0, "total_seconds": 0.0},
++        )
++        stats["segments"] += 1.0
++        start = safe_float(before_row.get("start"), default=0.0)
++        end = safe_float(before_row.get("end"), default=start)
++        stats["total_seconds"] += max(end - start, 0.0)
++    for speaker, stats in flicker_stats.items():
++        _logger.warning(
++            "Diarization flicker speaker reassigned: speaker=%s total_seconds=%.3f segments_reassigned=%d",
++            speaker,
++            stats["total_seconds"],
++            int(stats["segments"]),
++        )
+     unsmoothed_speaker_turns = build_speaker_turns(
+         language_segments,
+         ctx.diarization_segments,
+diff --git a/lan_transcriber/pipeline_steps/diarization_quality.py b/lan_transcriber/pipeline_steps/diarization_quality.py
+index 32dcaa4..1763111 100644
+--- a/lan_transcriber/pipeline_steps/diarization_quality.py
++++ b/lan_transcriber/pipeline_steps/diarization_quality.py
+@@ -15,6 +15,8 @@ DEFAULT_DIALOG_RETRY_MIN_DURATION_SECONDS = 20.0
+ DEFAULT_DIALOG_RETRY_MIN_TURNS = 6
+ DEFAULT_DIARIZATION_MERGE_GAP_SECONDS = 0.5
+ DEFAULT_DIARIZATION_MIN_TURN_SECONDS = 0.5
++DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS = 3.0
++DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE = 2
+ AUTO_PROFILE_DEFAULT_INITIAL_PROFILE = "meeting"
+ AUTO_PROFILE_DIALOG_MAX_SPEAKERS = 4
+ AUTO_PROFILE_DIALOG_MIN_TOP_TWO_COVERAGE = 0.85
+@@ -557,6 +559,123 @@ def smooth_speaker_turns(
+     )
  
  
- def _normalise_word(word: dict[str, Any], seg_start: float, seg_end: float) -> dict[str, Any] | None:
-@@ -231,7 +240,7 @@ def merge_short_turns(
-     turns: Sequence[dict[str, Any]],
-     *,
-     min_words: int = DEFAULT_SPEAKER_TURN_MIN_WORDS,
--    merge_gap_sec: float = DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,
-+    merge_gap_sec: float = DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC,
- ) -> list[dict[str, Any]]:
-     """Merge short speaker turns into adjacent turns from the same speaker.
- 
-@@ -242,6 +251,11 @@ def merge_short_turns(
-     neighbour shares the same speaker and the inter-turn gap is below
-     ``merge_gap_sec`` seconds. Short turns whose neighbours are different
-     speakers are kept as-is so no transcript content is discarded.
++def _segment_distance(
++    segment: dict[str, Any],
++    other: dict[str, Any],
++) -> float:
++    seg_start = safe_float(segment.get("start"), default=0.0)
++    seg_end = safe_float(segment.get("end"), default=seg_start)
++    other_start = safe_float(other.get("start"), default=0.0)
++    other_end = safe_float(other.get("end"), default=other_start)
++    if other_end < seg_start:
++        return seg_start - other_end
++    if other_start > seg_end:
++        return other_start - seg_end
++    return 0.0
 +
-+    ``merge_gap_sec`` should be strictly larger than the gap used by
-+    :func:`build_speaker_turns`, otherwise this post-pass is a no-op: every
-+    same-speaker pair within the base merge gap has already been collapsed by
-+    that earlier pass.
-     """
-     out: list[dict[str, Any]] = []
-     pending: list[dict[str, Any]] = [dict(turn) for turn in turns if isinstance(turn, dict)]
-@@ -398,6 +412,7 @@ __all__ = [
-     "DEFAULT_INTERRUPTION_OVERLAP_SEC",
-     "DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC",
-     "DEFAULT_SPEAKER_TURN_MIN_WORDS",
-+    "DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC",
-     "normalise_asr_segments",
-     "build_speaker_turns",
-     "merge_short_turns",
-diff --git a/tests/test_pipeline_steps_speaker_turns.py b/tests/test_pipeline_steps_speaker_turns.py
-index c3616cd..f173887 100644
---- a/tests/test_pipeline_steps_speaker_turns.py
-+++ b/tests/test_pipeline_steps_speaker_turns.py
-@@ -3,6 +3,7 @@ from __future__ import annotations
- from lan_transcriber.pipeline_steps.speaker_turns import (
-     DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,
-     DEFAULT_SPEAKER_TURN_MIN_WORDS,
-+    DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC,
-     build_speaker_turns,
-     count_interruptions,
-     merge_short_turns,
-@@ -173,6 +174,57 @@ def test_merge_short_turns_empty():
-     assert merge_short_turns([]) == []
- 
- 
-+def test_merge_short_turns_default_gap_exceeds_base_merge_gap():
-+    """The post-pass default must exceed the base merge gap to do real work.
 +
-+    After ``build_speaker_turns`` runs with the base ``merge_gap_sec``, every
-+    surviving same-speaker pair has a gap strictly greater than that base
-+    threshold. The short-turn post-pass therefore needs a strictly larger
-+    default in order to ever fire on real pipeline output. This test pins both
-+    invariants and exercises the case where ``build_speaker_turns`` left a
-+    short same-speaker continuation split because the gap exceeded the base
-+    merge threshold, and the post-pass still folds it back together.
++def filter_flickering_speakers(
++    diar_segments: list[dict[str, Any]],
++    *,
++    min_total_seconds: float = DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
++    max_consecutive_segments: int = DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
++) -> list[dict[str, Any]]:
++    """Reassign brief, isolated diarization speakers to nearest stable speaker.
++
++    A speaker is considered a "flicker" speaker when both conditions hold:
++    - the speaker's total speech duration across ``diar_segments`` is strictly
++      less than ``min_total_seconds``;
++    - the speaker never appears in more than ``max_consecutive_segments``
++      consecutive diarization segments (i.e. they only show up as brief
++      isolated bursts surrounded by other speakers).
++
++    Each diarization segment whose speaker is a flicker is relabelled with the
++    speaker of the closest non-flicker segment by time proximity. If every
++    speaker in the input is a flicker speaker (e.g. very short recording with
++    only tiny bursts), the original list is returned unchanged so no transcript
++    content is lost.
++
++    The returned list is sorted by start time.
 +    """
-+    assert DEFAULT_SPEAKER_TURN_SHORT_MERGE_GAP_SEC > DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC
 +
-+    long_text = " ".join(f"word{i}" for i in range(20))
-+    asr_segments = [
-+        {
-+            "start": 0.0,
-+            "end": 5.0,
-+            "text": long_text,
-+            "words": [
-+                {"start": float(i) * 0.25, "end": float(i) * 0.25 + 0.2, "word": f"word{i}"}
-+                for i in range(20)
-+            ],
-+        },
-+        {
-+            "start": 11.0,
-+            "end": 11.5,
-+            "text": "ok",
-+            "words": [{"start": 11.0, "end": 11.5, "word": "ok"}],
-+        },
-+    ]
-+    diar_segments = [{"start": 0.0, "end": 12.0, "speaker": "S1"}]
++    if not diar_segments:
++        return []
 +
-+    base_turns = build_speaker_turns(
-+        asr_segments,
-+        diar_segments,
-+        default_language=None,
++    sorted_segments = sorted(
++        (dict(seg) for seg in diar_segments),
++        key=lambda row: (
++            safe_float(row.get("start"), default=0.0),
++            safe_float(row.get("end"), default=0.0),
++            str(row.get("speaker") or ""),
++        ),
 +    )
 +
-+    # build_speaker_turns left these split because the inter-turn gap (~6s)
-+    # exceeds the base merge_gap_sec default (4s).
-+    assert len(base_turns) == 2
-+    assert base_turns[0]["speaker"] == base_turns[1]["speaker"] == "S1"
++    totals: dict[str, float] = {}
++    for seg in sorted_segments:
++        speaker = str(seg.get("speaker") or "")
++        totals[speaker] = totals.get(speaker, 0.0) + _segment_duration(seg)
 +
-+    merged = merge_short_turns(base_turns)
-+    assert len(merged) == 1
-+    assert merged[0]["text"].endswith("ok")
-+    assert merged[0]["start"] == 0.0
-+    assert merged[0]["end"] == 11.5
++    max_run: dict[str, int] = {}
++    current_speaker: str | None = None
++    current_run = 0
++    for seg in sorted_segments:
++        speaker = str(seg.get("speaker") or "")
++        if speaker == current_speaker:
++            current_run += 1
++        else:
++            current_speaker = speaker
++            current_run = 1
++        if current_run > max_run.get(speaker, 0):
++            max_run[speaker] = current_run
++
++    safe_min_total = max(safe_float(min_total_seconds, default=0.0), 0.0)
++    safe_max_consecutive = max(int(max_consecutive_segments), 0)
++
++    flicker_speakers = {
++        speaker
++        for speaker, total in totals.items()
++        if total < safe_min_total
++        and max_run.get(speaker, 0) <= safe_max_consecutive
++    }
++
++    if not flicker_speakers:
++        return sorted_segments
++
++    non_flicker_segments = [
++        seg
++        for seg in sorted_segments
++        if str(seg.get("speaker") or "") not in flicker_speakers
++    ]
++    if not non_flicker_segments:
++        return sorted_segments
++
++    cleaned: list[dict[str, Any]] = []
++    for seg in sorted_segments:
++        speaker = str(seg.get("speaker") or "")
++        if speaker in flicker_speakers:
++            nearest = min(
++                non_flicker_segments,
++                key=lambda candidate: (
++                    _segment_distance(seg, candidate),
++                    safe_float(candidate.get("start"), default=0.0),
++                ),
++            )
++            new_segment = dict(seg)
++            new_segment["speaker"] = str(nearest.get("speaker") or "")
++            cleaned.append(new_segment)
++        else:
++            cleaned.append(dict(seg))
++
++    cleaned.sort(
++        key=lambda row: (
++            safe_float(row.get("start"), default=0.0),
++            safe_float(row.get("end"), default=0.0),
++            str(row.get("speaker") or ""),
++        )
++    )
++    return cleaned
 +
 +
- def test_count_interruptions_small_synthetic_case():
-     turns = [
-         {"start": 0.0, "end": 4.0, "speaker": "S1", "text": "long turn"},
+ __all__ = [
+     "AUTO_PROFILE_DEFAULT_INITIAL_PROFILE",
+     "AUTO_PROFILE_DIALOG_MAX_OVERLAP_RATIO",
+@@ -572,6 +691,8 @@ __all__ = [
+     "DEFAULT_DIALOG_MIN_SPEAKERS",
+     "DEFAULT_DIALOG_RETRY_MIN_DURATION_SECONDS",
+     "DEFAULT_DIALOG_RETRY_MIN_TURNS",
++    "DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE",
++    "DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS",
+     "DEFAULT_DIARIZATION_MERGE_GAP_SECONDS",
+     "DEFAULT_DIARIZATION_MIN_TURN_SECONDS",
+     "DEFAULT_MEETING_MAX_SPEAKERS",
+@@ -584,6 +705,7 @@ __all__ = [
+     "choose_dialog_retry_winner",
+     "classify_diarization_profile",
+     "diarization_profile_metrics",
++    "filter_flickering_speakers",
+     "profile_default_speaker_hints",
+     "smooth_speaker_turns",
+ ]
+diff --git a/lan_transcriber/pipeline_steps/orchestrator.py b/lan_transcriber/pipeline_steps/orchestrator.py
+index 105f1c9..6578926 100644
+--- a/lan_transcriber/pipeline_steps/orchestrator.py
++++ b/lan_transcriber/pipeline_steps/orchestrator.py
+@@ -63,11 +63,14 @@ from .precheck import PrecheckResult, run_precheck as _run_precheck
+ from .diarization_quality import (
+     DEFAULT_DIALOG_RETRY_MIN_DURATION_SECONDS,
+     DEFAULT_DIALOG_RETRY_MIN_TURNS,
++    DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
++    DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
+     DEFAULT_DIARIZATION_MERGE_GAP_SECONDS,
+     DEFAULT_DIARIZATION_MIN_TURN_SECONDS,
+     SpeakerTurnSmoothingResult,
+     choose_dialog_retry_winner,
+     classify_diarization_profile,
++    filter_flickering_speakers,
+     smooth_speaker_turns,
+ )
+ from .snippets import SnippetExportRequest, export_speaker_snippets, write_empty_snippets_manifest
+@@ -391,6 +394,24 @@ class Settings(BaseSettings):
+         default=DEFAULT_DIARIZATION_MIN_TURN_SECONDS,
+         ge=0.0,
+     )
++    diarization_flicker_min_seconds: float = Field(
++        default=DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
++        ge=0.0,
++        validation_alias=AliasChoices(
++            "diarization_flicker_min_seconds",
++            "DIARIZATION_FLICKER_MIN_SECONDS",
++            "LAN_DIARIZATION_FLICKER_MIN_SECONDS",
++        ),
++    )
++    diarization_flicker_max_consecutive: int = Field(
++        default=DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
++        ge=0,
++        validation_alias=AliasChoices(
++            "diarization_flicker_max_consecutive",
++            "DIARIZATION_FLICKER_MAX_CONSECUTIVE",
++            "LAN_DIARIZATION_FLICKER_MAX_CONSECUTIVE",
++        ),
++    )
+     speaker_turn_merge_gap_sec: float = Field(
+         default=DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,
+         ge=0.0,
+@@ -2823,6 +2844,42 @@ async def run_pipeline(
+             used_dummy_fallback = True
+             _best_effort_step_log(step_log_callback, "diarization output empty; using fallback single-speaker annotation")
+             diar_segments = _diarization_segments(_fallback_diarization(max(fallback_end, 0.1)))
++        diar_segments_before_flicker = sorted(
++            diar_segments,
++            key=lambda row: (
++                safe_float(row.get("start"), default=0.0),
++                safe_float(row.get("end"), default=0.0),
++                str(row.get("speaker") or ""),
++            ),
++        )
++        diar_segments = filter_flickering_speakers(
++            diar_segments_before_flicker,
++            min_total_seconds=cfg.diarization_flicker_min_seconds,
++            max_consecutive_segments=cfg.diarization_flicker_max_consecutive,
++        )
++        flicker_stats: dict[str, dict[str, float]] = {}
++        for before_row, after_row in zip(
++            diar_segments_before_flicker, diar_segments
++        ):
++            before_speaker = str(before_row.get("speaker") or "")
++            after_speaker = str(after_row.get("speaker") or "")
++            if before_speaker == after_speaker:
++                continue
++            stats = flicker_stats.setdefault(
++                before_speaker,
++                {"segments": 0.0, "total_seconds": 0.0},
++            )
++            stats["segments"] += 1.0
++            start = safe_float(before_row.get("start"), default=0.0)
++            end = safe_float(before_row.get("end"), default=start)
++            stats["total_seconds"] += max(end - start, 0.0)
++        for speaker, stats in flicker_stats.items():
++            _logger.warning(
++                "Diarization flicker speaker reassigned: speaker=%s total_seconds=%.3f segments_reassigned=%d",
++                speaker,
++                stats["total_seconds"],
++                int(stats["segments"]),
++            )
+         unsmoothed_speaker_turns = build_speaker_turns(
+             language_analysis.segments,
+             diar_segments,
+diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
+index 1e8ddaf..6c2526b 100644
+--- a/tasks/QUEUE.md
++++ b/tasks/QUEUE.md
+@@ -664,7 +664,7 @@ Queue (in order)
+ - Depends on: PR-UI-POLISH-02
+ 
+ 133) PR-DIARIZATION-FLICKER-01: Filter out flickering diarization speakers that appear briefly surrounded by the same dominant speaker
+-- Status: TODO
++- Status: DONE
+ - Tasks file: tasks/PR-DIARIZATION-FLICKER-01.md
+ - Depends on: PR-TRANSCRIPT-MERGE-01
+ 
+diff --git a/tests/test_cov_lan_transcriber_extra_pipeline.py b/tests/test_cov_lan_transcriber_extra_pipeline.py
+index c68d75d..1ea242f 100644
+--- a/tests/test_cov_lan_transcriber_extra_pipeline.py
++++ b/tests/test_cov_lan_transcriber_extra_pipeline.py
+@@ -3317,6 +3317,61 @@ def test_whisperx_asr_align_typeerror_and_exception_paths(
+     assert segments[0]["text"] == "a"
+ 
+ 
++@pytest.mark.asyncio
++async def test_run_pipeline_logs_flicker_speaker_reassignment(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++    caplog: pytest.LogCaptureFixture,
++) -> None:
++    monkeypatch.setattr(
++        pipeline,
++        "_whisperx_asr",
++        lambda *_a, **_k: (
++            [
++                {"start": 0.0, "end": 1.0, "text": "alpha beta gamma delta epsilon"},
++                {"start": 1.0, "end": 2.0, "text": "zeta eta theta iota kappa"},
++                {"start": 2.0, "end": 3.0, "text": "lambda mu nu xi omicron"},
++            ],
++            {"language": "en", "language_probability": 0.95},
++        ),
++    )
++    monkeypatch.setattr(pipeline, "_sentiment_score", lambda _text: 50)
++    monkeypatch.setattr(pipeline, "export_speaker_snippets", lambda _req: [])
++    monkeypatch.setattr(pipeline, "_save_aliases", lambda *_a, **_k: None)
++    monkeypatch.setattr(pipeline, "_load_aliases", lambda *_a, **_k: {})
++
++    class _FlickerDiariser:
++        async def __call__(self, _audio_path: Path):
++            return _annotation_from_segments(
++                (0.0, 5.0, "S_MAIN"),
++                (1.0, 1.2, "S_FLICKER"),
++                (5.0, 12.0, "S_MAIN"),
++            )
++
++    cfg = _settings(tmp_path)
++    caplog.set_level("WARNING", logger="lan_transcriber.pipeline_steps.orchestrator")
++    result = await pipeline.run_pipeline(
++        audio_path=_audio_file(tmp_path, "flicker.mp3"),
++        cfg=cfg,
++        llm=_FakeLLM(),
++        diariser=_FlickerDiariser(),
++        recording_id="rec-flicker",
++        precheck=pipeline.PrecheckResult(
++            duration_sec=30.0, speech_ratio=0.8, quarantine_reason=None
++        ),
++    )
++    assert result.summary.strip() == "- ok"
++    assert any(
++        "Diarization flicker speaker reassigned" in record.getMessage()
++        and "S_FLICKER" in record.getMessage()
++        for record in caplog.records
++    )
++
++    derived = cfg.recordings_root / "rec-flicker" / "derived"
++    diar_data = json.loads((derived / "segments.json").read_text(encoding="utf-8"))
++    assert all(row["speaker"] != "S_FLICKER" for row in diar_data)
++
++
+ @pytest.mark.asyncio
+ async def test_run_pipeline_backfills_detected_language_and_uses_fallback_diarization(
+     tmp_path: Path,
+diff --git a/tests/test_diarization_quality.py b/tests/test_diarization_quality.py
+index 4332396..9cc704e 100644
+--- a/tests/test_diarization_quality.py
++++ b/tests/test_diarization_quality.py
+@@ -16,6 +16,7 @@ from lan_transcriber.pipeline_steps.diarization_quality import (
+     choose_dialog_retry_winner,
+     classify_diarization_profile,
+     diarization_profile_metrics,
++    filter_flickering_speakers,
+     profile_default_speaker_hints,
+     smooth_speaker_turns,
+ )
+@@ -426,6 +427,76 @@ def test_smooth_speaker_turns_absorbs_micro_turns_but_preserves_real_changes():
+     assert [turn["speaker"] for turn in preserved.turns] == ["S1", "S2", "S1", "S1"]
+ 
+ 
++def test_flicker_speaker_reassigned():
++    diar_segments = [
++        {"start": float(idx), "end": float(idx) + 1.0, "speaker": "SPEAKER_01"}
++        for idx in range(5)
++    ]
++    diar_segments.append({"start": 5.0, "end": 5.5, "speaker": "SPEAKER_00"})
++    diar_segments.extend(
++        {"start": float(idx), "end": float(idx) + 1.0, "speaker": "SPEAKER_01"}
++        for idx in range(6, 11)
++    )
++
++    cleaned = filter_flickering_speakers(diar_segments)
++
++    assert len(cleaned) == len(diar_segments)
++    speakers = {row["speaker"] for row in cleaned}
++    assert speakers == {"SPEAKER_01"}
++    flicker_row = next(row for row in cleaned if row["start"] == 5.0 and row["end"] == 5.5)
++    assert flicker_row["speaker"] == "SPEAKER_01"
++
++
++def test_legitimate_speaker_kept():
++    diar_segments = [
++        {"start": float(idx) * 2.0, "end": float(idx) * 2.0 + 1.5, "speaker": "SPEAKER_01"}
++        for idx in range(10)
++    ]
++    diar_segments.extend(
++        {
++            "start": 100.0 + float(idx) * 2.0,
++            "end": 100.0 + float(idx) * 2.0 + 1.6,
++            "speaker": "SPEAKER_00",
++        }
++        for idx in range(5)
++    )
++
++    cleaned = filter_flickering_speakers(diar_segments)
++
++    speakers = {row["speaker"] for row in cleaned}
++    assert speakers == {"SPEAKER_00", "SPEAKER_01"}
++    assert sum(1 for row in cleaned if row["speaker"] == "SPEAKER_00") == 5
++
++
++def test_all_speakers_flicker_unchanged():
++    diar_segments = [
++        {"start": 0.0, "end": 1.0, "speaker": "SPEAKER_00"},
++        {"start": 1.0, "end": 2.0, "speaker": "SPEAKER_01"},
++    ]
++
++    cleaned = filter_flickering_speakers(diar_segments)
++
++    assert cleaned == diar_segments
++
++
++def test_empty_segments():
++    assert filter_flickering_speakers([]) == []
++
++
++def test_flicker_reassigned_to_nearest():
++    diar_segments = [
++        {"start": 0.0, "end": 10.0, "speaker": "SPEAKER_01"},
++        {"start": 12.0, "end": 12.5, "speaker": "SPEAKER_00"},
++        {"start": 15.0, "end": 25.0, "speaker": "SPEAKER_02"},
++    ]
++
++    cleaned = filter_flickering_speakers(diar_segments)
++
++    flicker_row = next(row for row in cleaned if row["start"] == 12.0)
++    assert flicker_row["speaker"] == "SPEAKER_01"
++    assert {row["speaker"] for row in cleaned} == {"SPEAKER_01", "SPEAKER_02"}
++
++
+ def test_smooth_speaker_turns_handles_empty_input_and_private_guards():
+     result = smooth_speaker_turns([])
+ 
+diff --git a/tests/test_pipeline_resume_coverage.py b/tests/test_pipeline_resume_coverage.py
+index 9b2d1ca..b9d06ba 100644
+--- a/tests/test_pipeline_resume_coverage.py
++++ b/tests/test_pipeline_resume_coverage.py
+@@ -750,6 +750,66 @@ def test_stage_speaker_turns_requires_language_artifact_and_supports_unsmoothed_
+     assert result.metadata == {"turn_count": 1, "speaker_count": 1}
+ 
+ 
++def test_stage_speaker_turns_logs_flicker_speaker_reassignment(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++    caplog: pytest.LogCaptureFixture,
++) -> None:
++    _cfg_value, ctx = _new_ctx(tmp_path, "rec-flicker-stage")
++    ctx.precheck_result = PrecheckResult(10.0, 0.5, None)
++    ctx.artifacts.language_analysis_json_path.write_text(
++        json.dumps(
++            {
++                "dominant_language": "en",
++                "language": {"detected": "en", "confidence": 0.95},
++                "segments": [
++                    {"start": 0.0, "end": 1.0, "text": "hello", "language": "en"}
++                ],
++            }
++        ),
++        encoding="utf-8",
++    )
++    ctx.artifacts.diarization_segments_json_path.write_text(
++        json.dumps(
++            [
++                {"speaker": "S_MAIN", "start": 0.0, "end": 5.0},
++                {"speaker": "S_FLICKER", "start": 1.0, "end": 1.2},
++                {"speaker": "S_MAIN", "start": 5.0, "end": 12.0},
++            ]
++        ),
++        encoding="utf-8",
++    )
++    ctx.artifacts.diarization_runtime_json_path.write_text(
++        json.dumps({"mode": "fallback", "used_dummy_fallback": False}),
++        encoding="utf-8",
++    )
++    monkeypatch.setattr(
++        worker_tasks,
++        "build_speaker_turns",
++        lambda *_a, **_k: [
++            {"speaker": "S_MAIN", "start": 0.0, "end": 12.0, "text": "hello"}
++        ],
++    )
++    monkeypatch.setattr(
++        worker_tasks,
++        "smooth_speaker_turns",
++        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("should not smooth")),
++    )
++
++    caplog.set_level("WARNING", logger="lan_app.worker_tasks")
++    result = worker_tasks._stage_speaker_turns(ctx)  # noqa: SLF001
++
++    assert result.status == "completed"
++    assert any(
++        "Diarization flicker speaker reassigned" in record.getMessage()
++        and "S_FLICKER" in record.getMessage()
++        for record in caplog.records
++    )
++    assert all(
++        row["speaker"] != "S_FLICKER" for row in ctx.diarization_segments
++    )
++
++
+ def test_stage_snippet_export_writes_manifest_metadata_and_counts(
+     tmp_path: Path,
+     monkeypatch: pytest.MonkeyPatch,

--- a/lan_app/config.py
+++ b/lan_app/config.py
@@ -12,6 +12,8 @@ from lan_app.constants import DEFAULT_RQ_QUEUE_NAME
 from lan_transcriber.pipeline_steps.diarization_quality import (
     DEFAULT_DIALOG_RETRY_MIN_DURATION_SECONDS,
     DEFAULT_DIALOG_RETRY_MIN_TURNS,
+    DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
+    DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
     DEFAULT_DIARIZATION_MERGE_GAP_SECONDS,
     DEFAULT_DIARIZATION_MIN_TURN_SECONDS,
 )
@@ -318,6 +320,22 @@ class AppSettings(BaseSettings):
     diarization_min_turn_seconds: float = Field(
         default=DEFAULT_DIARIZATION_MIN_TURN_SECONDS,
         ge=0.0,
+    )
+    diarization_flicker_min_seconds: float = Field(
+        default=DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
+        ge=0.0,
+        validation_alias=AliasChoices(
+            "LAN_DIARIZATION_FLICKER_MIN_SECONDS",
+            "DIARIZATION_FLICKER_MIN_SECONDS",
+        ),
+    )
+    diarization_flicker_max_consecutive: int = Field(
+        default=DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
+        ge=0,
+        validation_alias=AliasChoices(
+            "LAN_DIARIZATION_FLICKER_MAX_CONSECUTIVE",
+            "DIARIZATION_FLICKER_MAX_CONSECUTIVE",
+        ),
     )
     speaker_turn_merge_gap_sec: float = Field(
         default=DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,

--- a/lan_app/worker_tasks.py
+++ b/lan_app/worker_tasks.py
@@ -44,6 +44,7 @@ from lan_transcriber.pipeline_steps.diarization_quality import (
     DEFAULT_DIALOG_RETRY_MIN_TURNS,
     SpeakerTurnSmoothingResult,
     annotation_speaker_count,
+    filter_flickering_speakers,
     profile_default_speaker_hints,
     smooth_speaker_turns,
 )
@@ -1882,6 +1883,8 @@ def _build_pipeline_settings(settings: AppSettings) -> PipelineSettings:
         diarization_dialog_retry_min_turns=settings.diarization_dialog_retry_min_turns,
         diarization_merge_gap_seconds=settings.diarization_merge_gap_seconds,
         diarization_min_turn_seconds=settings.diarization_min_turn_seconds,
+        diarization_flicker_min_seconds=settings.diarization_flicker_min_seconds,
+        diarization_flicker_max_consecutive=settings.diarization_flicker_max_consecutive,
         speaker_turn_merge_gap_sec=settings.speaker_turn_merge_gap_sec,
         speaker_turn_short_merge_gap_sec=settings.speaker_turn_short_merge_gap_sec,
         speaker_turn_min_words=settings.speaker_turn_min_words,
@@ -2940,6 +2943,42 @@ def _stage_speaker_turns(ctx: _PipelineExecutionContext) -> _StageResult:
     detected_language = normalise_language_code(
         (ctx.language_payload.get("language") or {}).get("detected")
     )
+    diarization_segments_before_flicker = sorted(
+        ctx.diarization_segments,
+        key=lambda row: (
+            safe_float(row.get("start"), default=0.0),
+            safe_float(row.get("end"), default=0.0),
+            str(row.get("speaker") or ""),
+        ),
+    )
+    ctx.diarization_segments = filter_flickering_speakers(
+        diarization_segments_before_flicker,
+        min_total_seconds=ctx.pipeline_settings.diarization_flicker_min_seconds,
+        max_consecutive_segments=ctx.pipeline_settings.diarization_flicker_max_consecutive,
+    )
+    flicker_stats: dict[str, dict[str, float]] = {}
+    for before_row, after_row in zip(
+        diarization_segments_before_flicker, ctx.diarization_segments
+    ):
+        before_speaker = str(before_row.get("speaker") or "")
+        after_speaker = str(after_row.get("speaker") or "")
+        if before_speaker == after_speaker:
+            continue
+        stats = flicker_stats.setdefault(
+            before_speaker,
+            {"segments": 0.0, "total_seconds": 0.0},
+        )
+        stats["segments"] += 1.0
+        start = safe_float(before_row.get("start"), default=0.0)
+        end = safe_float(before_row.get("end"), default=start)
+        stats["total_seconds"] += max(end - start, 0.0)
+    for speaker, stats in flicker_stats.items():
+        _logger.warning(
+            "Diarization flicker speaker reassigned: speaker=%s total_seconds=%.3f segments_reassigned=%d",
+            speaker,
+            stats["total_seconds"],
+            int(stats["segments"]),
+        )
     unsmoothed_speaker_turns = build_speaker_turns(
         language_segments,
         ctx.diarization_segments,

--- a/lan_transcriber/pipeline_steps/diarization_quality.py
+++ b/lan_transcriber/pipeline_steps/diarization_quality.py
@@ -15,6 +15,8 @@ DEFAULT_DIALOG_RETRY_MIN_DURATION_SECONDS = 20.0
 DEFAULT_DIALOG_RETRY_MIN_TURNS = 6
 DEFAULT_DIARIZATION_MERGE_GAP_SECONDS = 0.5
 DEFAULT_DIARIZATION_MIN_TURN_SECONDS = 0.5
+DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS = 3.0
+DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE = 2
 AUTO_PROFILE_DEFAULT_INITIAL_PROFILE = "meeting"
 AUTO_PROFILE_DIALOG_MAX_SPEAKERS = 4
 AUTO_PROFILE_DIALOG_MIN_TOP_TWO_COVERAGE = 0.85
@@ -557,6 +559,123 @@ def smooth_speaker_turns(
     )
 
 
+def _segment_distance(
+    segment: dict[str, Any],
+    other: dict[str, Any],
+) -> float:
+    seg_start = safe_float(segment.get("start"), default=0.0)
+    seg_end = safe_float(segment.get("end"), default=seg_start)
+    other_start = safe_float(other.get("start"), default=0.0)
+    other_end = safe_float(other.get("end"), default=other_start)
+    if other_end < seg_start:
+        return seg_start - other_end
+    if other_start > seg_end:
+        return other_start - seg_end
+    return 0.0
+
+
+def filter_flickering_speakers(
+    diar_segments: list[dict[str, Any]],
+    *,
+    min_total_seconds: float = DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
+    max_consecutive_segments: int = DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
+) -> list[dict[str, Any]]:
+    """Reassign brief, isolated diarization speakers to nearest stable speaker.
+
+    A speaker is considered a "flicker" speaker when both conditions hold:
+    - the speaker's total speech duration across ``diar_segments`` is strictly
+      less than ``min_total_seconds``;
+    - the speaker never appears in more than ``max_consecutive_segments``
+      consecutive diarization segments (i.e. they only show up as brief
+      isolated bursts surrounded by other speakers).
+
+    Each diarization segment whose speaker is a flicker is relabelled with the
+    speaker of the closest non-flicker segment by time proximity. If every
+    speaker in the input is a flicker speaker (e.g. very short recording with
+    only tiny bursts), the original list is returned unchanged so no transcript
+    content is lost.
+
+    The returned list is sorted by start time.
+    """
+
+    if not diar_segments:
+        return []
+
+    sorted_segments = sorted(
+        (dict(seg) for seg in diar_segments),
+        key=lambda row: (
+            safe_float(row.get("start"), default=0.0),
+            safe_float(row.get("end"), default=0.0),
+            str(row.get("speaker") or ""),
+        ),
+    )
+
+    totals: dict[str, float] = {}
+    for seg in sorted_segments:
+        speaker = str(seg.get("speaker") or "")
+        totals[speaker] = totals.get(speaker, 0.0) + _segment_duration(seg)
+
+    max_run: dict[str, int] = {}
+    current_speaker: str | None = None
+    current_run = 0
+    for seg in sorted_segments:
+        speaker = str(seg.get("speaker") or "")
+        if speaker == current_speaker:
+            current_run += 1
+        else:
+            current_speaker = speaker
+            current_run = 1
+        if current_run > max_run.get(speaker, 0):
+            max_run[speaker] = current_run
+
+    safe_min_total = max(safe_float(min_total_seconds, default=0.0), 0.0)
+    safe_max_consecutive = max(int(max_consecutive_segments), 0)
+
+    flicker_speakers = {
+        speaker
+        for speaker, total in totals.items()
+        if total < safe_min_total
+        and max_run.get(speaker, 0) <= safe_max_consecutive
+    }
+
+    if not flicker_speakers:
+        return sorted_segments
+
+    non_flicker_segments = [
+        seg
+        for seg in sorted_segments
+        if str(seg.get("speaker") or "") not in flicker_speakers
+    ]
+    if not non_flicker_segments:
+        return sorted_segments
+
+    cleaned: list[dict[str, Any]] = []
+    for seg in sorted_segments:
+        speaker = str(seg.get("speaker") or "")
+        if speaker in flicker_speakers:
+            nearest = min(
+                non_flicker_segments,
+                key=lambda candidate: (
+                    _segment_distance(seg, candidate),
+                    safe_float(candidate.get("start"), default=0.0),
+                ),
+            )
+            new_segment = dict(seg)
+            new_segment["speaker"] = str(nearest.get("speaker") or "")
+            cleaned.append(new_segment)
+        else:
+            cleaned.append(dict(seg))
+
+    cleaned.sort(
+        key=lambda row: (
+            safe_float(row.get("start"), default=0.0),
+            safe_float(row.get("end"), default=0.0),
+            str(row.get("speaker") or ""),
+        )
+    )
+    return cleaned
+
+
 __all__ = [
     "AUTO_PROFILE_DEFAULT_INITIAL_PROFILE",
     "AUTO_PROFILE_DIALOG_MAX_OVERLAP_RATIO",
@@ -572,6 +691,8 @@ __all__ = [
     "DEFAULT_DIALOG_MIN_SPEAKERS",
     "DEFAULT_DIALOG_RETRY_MIN_DURATION_SECONDS",
     "DEFAULT_DIALOG_RETRY_MIN_TURNS",
+    "DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE",
+    "DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS",
     "DEFAULT_DIARIZATION_MERGE_GAP_SECONDS",
     "DEFAULT_DIARIZATION_MIN_TURN_SECONDS",
     "DEFAULT_MEETING_MAX_SPEAKERS",
@@ -584,6 +705,7 @@ __all__ = [
     "choose_dialog_retry_winner",
     "classify_diarization_profile",
     "diarization_profile_metrics",
+    "filter_flickering_speakers",
     "profile_default_speaker_hints",
     "smooth_speaker_turns",
 ]

--- a/lan_transcriber/pipeline_steps/orchestrator.py
+++ b/lan_transcriber/pipeline_steps/orchestrator.py
@@ -63,11 +63,14 @@ from .precheck import PrecheckResult, run_precheck as _run_precheck
 from .diarization_quality import (
     DEFAULT_DIALOG_RETRY_MIN_DURATION_SECONDS,
     DEFAULT_DIALOG_RETRY_MIN_TURNS,
+    DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
+    DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
     DEFAULT_DIARIZATION_MERGE_GAP_SECONDS,
     DEFAULT_DIARIZATION_MIN_TURN_SECONDS,
     SpeakerTurnSmoothingResult,
     choose_dialog_retry_winner,
     classify_diarization_profile,
+    filter_flickering_speakers,
     smooth_speaker_turns,
 )
 from .snippets import SnippetExportRequest, export_speaker_snippets, write_empty_snippets_manifest
@@ -390,6 +393,24 @@ class Settings(BaseSettings):
     diarization_min_turn_seconds: float = Field(
         default=DEFAULT_DIARIZATION_MIN_TURN_SECONDS,
         ge=0.0,
+    )
+    diarization_flicker_min_seconds: float = Field(
+        default=DEFAULT_DIARIZATION_FLICKER_MIN_SECONDS,
+        ge=0.0,
+        validation_alias=AliasChoices(
+            "diarization_flicker_min_seconds",
+            "DIARIZATION_FLICKER_MIN_SECONDS",
+            "LAN_DIARIZATION_FLICKER_MIN_SECONDS",
+        ),
+    )
+    diarization_flicker_max_consecutive: int = Field(
+        default=DEFAULT_DIARIZATION_FLICKER_MAX_CONSECUTIVE,
+        ge=0,
+        validation_alias=AliasChoices(
+            "diarization_flicker_max_consecutive",
+            "DIARIZATION_FLICKER_MAX_CONSECUTIVE",
+            "LAN_DIARIZATION_FLICKER_MAX_CONSECUTIVE",
+        ),
     )
     speaker_turn_merge_gap_sec: float = Field(
         default=DEFAULT_SPEAKER_TURN_MERGE_GAP_SEC,
@@ -2823,6 +2844,42 @@ async def run_pipeline(
             used_dummy_fallback = True
             _best_effort_step_log(step_log_callback, "diarization output empty; using fallback single-speaker annotation")
             diar_segments = _diarization_segments(_fallback_diarization(max(fallback_end, 0.1)))
+        diar_segments_before_flicker = sorted(
+            diar_segments,
+            key=lambda row: (
+                safe_float(row.get("start"), default=0.0),
+                safe_float(row.get("end"), default=0.0),
+                str(row.get("speaker") or ""),
+            ),
+        )
+        diar_segments = filter_flickering_speakers(
+            diar_segments_before_flicker,
+            min_total_seconds=cfg.diarization_flicker_min_seconds,
+            max_consecutive_segments=cfg.diarization_flicker_max_consecutive,
+        )
+        flicker_stats: dict[str, dict[str, float]] = {}
+        for before_row, after_row in zip(
+            diar_segments_before_flicker, diar_segments
+        ):
+            before_speaker = str(before_row.get("speaker") or "")
+            after_speaker = str(after_row.get("speaker") or "")
+            if before_speaker == after_speaker:
+                continue
+            stats = flicker_stats.setdefault(
+                before_speaker,
+                {"segments": 0.0, "total_seconds": 0.0},
+            )
+            stats["segments"] += 1.0
+            start = safe_float(before_row.get("start"), default=0.0)
+            end = safe_float(before_row.get("end"), default=start)
+            stats["total_seconds"] += max(end - start, 0.0)
+        for speaker, stats in flicker_stats.items():
+            _logger.warning(
+                "Diarization flicker speaker reassigned: speaker=%s total_seconds=%.3f segments_reassigned=%d",
+                speaker,
+                stats["total_seconds"],
+                int(stats["segments"]),
+            )
         unsmoothed_speaker_turns = build_speaker_turns(
             language_analysis.segments,
             diar_segments,

--- a/tasks/QUEUE.md
+++ b/tasks/QUEUE.md
@@ -664,7 +664,7 @@ Queue (in order)
 - Depends on: PR-UI-POLISH-02
 
 133) PR-DIARIZATION-FLICKER-01: Filter out flickering diarization speakers that appear briefly surrounded by the same dominant speaker
-- Status: TODO
+- Status: DONE
 - Tasks file: tasks/PR-DIARIZATION-FLICKER-01.md
 - Depends on: PR-TRANSCRIPT-MERGE-01
 

--- a/tests/test_cov_lan_transcriber_extra_pipeline.py
+++ b/tests/test_cov_lan_transcriber_extra_pipeline.py
@@ -3318,6 +3318,61 @@ def test_whisperx_asr_align_typeerror_and_exception_paths(
 
 
 @pytest.mark.asyncio
+async def test_run_pipeline_logs_flicker_speaker_reassignment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(
+        pipeline,
+        "_whisperx_asr",
+        lambda *_a, **_k: (
+            [
+                {"start": 0.0, "end": 1.0, "text": "alpha beta gamma delta epsilon"},
+                {"start": 1.0, "end": 2.0, "text": "zeta eta theta iota kappa"},
+                {"start": 2.0, "end": 3.0, "text": "lambda mu nu xi omicron"},
+            ],
+            {"language": "en", "language_probability": 0.95},
+        ),
+    )
+    monkeypatch.setattr(pipeline, "_sentiment_score", lambda _text: 50)
+    monkeypatch.setattr(pipeline, "export_speaker_snippets", lambda _req: [])
+    monkeypatch.setattr(pipeline, "_save_aliases", lambda *_a, **_k: None)
+    monkeypatch.setattr(pipeline, "_load_aliases", lambda *_a, **_k: {})
+
+    class _FlickerDiariser:
+        async def __call__(self, _audio_path: Path):
+            return _annotation_from_segments(
+                (0.0, 5.0, "S_MAIN"),
+                (1.0, 1.2, "S_FLICKER"),
+                (5.0, 12.0, "S_MAIN"),
+            )
+
+    cfg = _settings(tmp_path)
+    caplog.set_level("WARNING", logger="lan_transcriber.pipeline_steps.orchestrator")
+    result = await pipeline.run_pipeline(
+        audio_path=_audio_file(tmp_path, "flicker.mp3"),
+        cfg=cfg,
+        llm=_FakeLLM(),
+        diariser=_FlickerDiariser(),
+        recording_id="rec-flicker",
+        precheck=pipeline.PrecheckResult(
+            duration_sec=30.0, speech_ratio=0.8, quarantine_reason=None
+        ),
+    )
+    assert result.summary.strip() == "- ok"
+    assert any(
+        "Diarization flicker speaker reassigned" in record.getMessage()
+        and "S_FLICKER" in record.getMessage()
+        for record in caplog.records
+    )
+
+    derived = cfg.recordings_root / "rec-flicker" / "derived"
+    diar_data = json.loads((derived / "segments.json").read_text(encoding="utf-8"))
+    assert all(row["speaker"] != "S_FLICKER" for row in diar_data)
+
+
+@pytest.mark.asyncio
 async def test_run_pipeline_backfills_detected_language_and_uses_fallback_diarization(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_diarization_quality.py
+++ b/tests/test_diarization_quality.py
@@ -16,6 +16,7 @@ from lan_transcriber.pipeline_steps.diarization_quality import (
     choose_dialog_retry_winner,
     classify_diarization_profile,
     diarization_profile_metrics,
+    filter_flickering_speakers,
     profile_default_speaker_hints,
     smooth_speaker_turns,
 )
@@ -424,6 +425,76 @@ def test_smooth_speaker_turns_absorbs_micro_turns_but_preserves_real_changes():
     assert preserved.micro_turn_absorptions == 0
     assert preserved.turn_count_after == 4
     assert [turn["speaker"] for turn in preserved.turns] == ["S1", "S2", "S1", "S1"]
+
+
+def test_flicker_speaker_reassigned():
+    diar_segments = [
+        {"start": float(idx), "end": float(idx) + 1.0, "speaker": "SPEAKER_01"}
+        for idx in range(5)
+    ]
+    diar_segments.append({"start": 5.0, "end": 5.5, "speaker": "SPEAKER_00"})
+    diar_segments.extend(
+        {"start": float(idx), "end": float(idx) + 1.0, "speaker": "SPEAKER_01"}
+        for idx in range(6, 11)
+    )
+
+    cleaned = filter_flickering_speakers(diar_segments)
+
+    assert len(cleaned) == len(diar_segments)
+    speakers = {row["speaker"] for row in cleaned}
+    assert speakers == {"SPEAKER_01"}
+    flicker_row = next(row for row in cleaned if row["start"] == 5.0 and row["end"] == 5.5)
+    assert flicker_row["speaker"] == "SPEAKER_01"
+
+
+def test_legitimate_speaker_kept():
+    diar_segments = [
+        {"start": float(idx) * 2.0, "end": float(idx) * 2.0 + 1.5, "speaker": "SPEAKER_01"}
+        for idx in range(10)
+    ]
+    diar_segments.extend(
+        {
+            "start": 100.0 + float(idx) * 2.0,
+            "end": 100.0 + float(idx) * 2.0 + 1.6,
+            "speaker": "SPEAKER_00",
+        }
+        for idx in range(5)
+    )
+
+    cleaned = filter_flickering_speakers(diar_segments)
+
+    speakers = {row["speaker"] for row in cleaned}
+    assert speakers == {"SPEAKER_00", "SPEAKER_01"}
+    assert sum(1 for row in cleaned if row["speaker"] == "SPEAKER_00") == 5
+
+
+def test_all_speakers_flicker_unchanged():
+    diar_segments = [
+        {"start": 0.0, "end": 1.0, "speaker": "SPEAKER_00"},
+        {"start": 1.0, "end": 2.0, "speaker": "SPEAKER_01"},
+    ]
+
+    cleaned = filter_flickering_speakers(diar_segments)
+
+    assert cleaned == diar_segments
+
+
+def test_empty_segments():
+    assert filter_flickering_speakers([]) == []
+
+
+def test_flicker_reassigned_to_nearest():
+    diar_segments = [
+        {"start": 0.0, "end": 10.0, "speaker": "SPEAKER_01"},
+        {"start": 12.0, "end": 12.5, "speaker": "SPEAKER_00"},
+        {"start": 15.0, "end": 25.0, "speaker": "SPEAKER_02"},
+    ]
+
+    cleaned = filter_flickering_speakers(diar_segments)
+
+    flicker_row = next(row for row in cleaned if row["start"] == 12.0)
+    assert flicker_row["speaker"] == "SPEAKER_01"
+    assert {row["speaker"] for row in cleaned} == {"SPEAKER_01", "SPEAKER_02"}
 
 
 def test_smooth_speaker_turns_handles_empty_input_and_private_guards():

--- a/tests/test_pipeline_resume_coverage.py
+++ b/tests/test_pipeline_resume_coverage.py
@@ -750,6 +750,66 @@ def test_stage_speaker_turns_requires_language_artifact_and_supports_unsmoothed_
     assert result.metadata == {"turn_count": 1, "speaker_count": 1}
 
 
+def test_stage_speaker_turns_logs_flicker_speaker_reassignment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _cfg_value, ctx = _new_ctx(tmp_path, "rec-flicker-stage")
+    ctx.precheck_result = PrecheckResult(10.0, 0.5, None)
+    ctx.artifacts.language_analysis_json_path.write_text(
+        json.dumps(
+            {
+                "dominant_language": "en",
+                "language": {"detected": "en", "confidence": 0.95},
+                "segments": [
+                    {"start": 0.0, "end": 1.0, "text": "hello", "language": "en"}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    ctx.artifacts.diarization_segments_json_path.write_text(
+        json.dumps(
+            [
+                {"speaker": "S_MAIN", "start": 0.0, "end": 5.0},
+                {"speaker": "S_FLICKER", "start": 1.0, "end": 1.2},
+                {"speaker": "S_MAIN", "start": 5.0, "end": 12.0},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    ctx.artifacts.diarization_runtime_json_path.write_text(
+        json.dumps({"mode": "fallback", "used_dummy_fallback": False}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        worker_tasks,
+        "build_speaker_turns",
+        lambda *_a, **_k: [
+            {"speaker": "S_MAIN", "start": 0.0, "end": 12.0, "text": "hello"}
+        ],
+    )
+    monkeypatch.setattr(
+        worker_tasks,
+        "smooth_speaker_turns",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("should not smooth")),
+    )
+
+    caplog.set_level("WARNING", logger="lan_app.worker_tasks")
+    result = worker_tasks._stage_speaker_turns(ctx)  # noqa: SLF001
+
+    assert result.status == "completed"
+    assert any(
+        "Diarization flicker speaker reassigned" in record.getMessage()
+        and "S_FLICKER" in record.getMessage()
+        for record in caplog.records
+    )
+    assert all(
+        row["speaker"] != "S_FLICKER" for row in ctx.diarization_segments
+    )
+
+
 def test_stage_snippet_export_writes_manifest_metadata_and_counts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Add `filter_flickering_speakers` in `lan_transcriber/pipeline_steps/diarization_quality.py` that reassigns diarization segments belonging to brief, isolated speakers (`< DIARIZATION_FLICKER_MIN_SECONDS` total AND never more than `DIARIZATION_FLICKER_MAX_CONSECUTIVE` consecutive segments) to the nearest non-flicker speaker by time proximity, leaving the input untouched when every speaker is a flicker.
- Wire the filter into the legacy `lan_transcriber.pipeline_steps.orchestrator` path and the modular `lan_app.worker_tasks._stage_speaker_turns` so flicker labels never reach `build_speaker_turns`; log a warning per reassigned speaker with total seconds and segment count.
- Add `DIARIZATION_FLICKER_MIN_SECONDS` (default 3.0s) and `DIARIZATION_FLICKER_MAX_CONSECUTIVE` (default 2) config knobs on both `AppSettings` and the orchestrator `Settings`, propagated through `worker_tasks._build_pipeline_settings`.

## PR_ID
PR-DIARIZATION-FLICKER-01

## Tasks file
[tasks/PR-DIARIZATION-FLICKER-01.md](tasks/PR-DIARIZATION-FLICKER-01.md)

## Branch
pr-diarization-flicker-01

## How verified
- ` INSTALL_DEPS=0 USE_VENV=1 bash scripts/ci.sh` (1071 passed, 3 skipped, 100% coverage)

## Artifacts
- artifacts/ci.log
- artifacts/pr.patch

## Test plan
- [x] Unit tests for `filter_flickering_speakers` cover: flicker reassignment, legitimate speaker kept, all-flicker unchanged, empty list, nearest-by-distance.
- [x] Integration tests assert the warning log fires and the persisted segments no longer reference the flicker speaker for both the legacy orchestrator path and the modular `_stage_speaker_turns`.

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)