### PR TITLE
PR-SPEAKER-MERGE-DIAGNOSTICS-01: add diagnostics for speaker merge step

### DIFF
--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -1,3 +1,119 @@
+Requirement already satisfied: pip in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (26.0.1)
+Requirement already satisfied: annotated-types==0.7.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 7)) (0.7.0)
+Requirement already satisfied: antlr4-python3-runtime==4.9.3 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 9)) (4.9.3)
+Requirement already satisfied: anyio==4.13.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 11)) (4.13.0)
+Requirement already satisfied: build==1.4.3 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 15)) (1.4.3)
+Requirement already satisfied: certifi==2026.2.25 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 17)) (2026.2.25)
+Requirement already satisfied: charset-normalizer==3.4.7 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 22)) (3.4.7)
+Requirement already satisfied: click==8.3.2 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 24)) (8.3.2)
+Requirement already satisfied: coverage==7.13.5 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from coverage[toml]==7.13.5->-r ci-requirements.txt (line 29)) (7.13.5)
+Requirement already satisfied: fastapi==0.116.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 31)) (0.116.1)
+Requirement already satisfied: h11==0.16.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 33)) (0.16.0)
+Requirement already satisfied: httpcore==1.0.9 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 37)) (1.0.9)
+Requirement already satisfied: httpx==0.28.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 39)) (0.28.1)
+Requirement already satisfied: icalendar==6.3.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 43)) (6.3.1)
+Requirement already satisfied: idna==3.11 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 48)) (3.11)
+Requirement already satisfied: iniconfig==2.3.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 53)) (2.3.0)
+Requirement already satisfied: omegaconf==2.3.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 55)) (2.3.0)
+Requirement already satisfied: packaging==26.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 57)) (26.0)
+Requirement already satisfied: pip-tools==7.4.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 61)) (7.4.1)
+Requirement already satisfied: pluggy==1.6.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 63)) (1.6.0)
+Requirement already satisfied: prometheus-client==0.25.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 65)) (0.25.0)
+Requirement already satisfied: pydantic==2.12.5 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 67)) (2.12.5)
+Requirement already satisfied: pydantic-core==2.41.5 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 71)) (2.41.5)
+Requirement already satisfied: pydantic-settings==2.10.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 73)) (2.10.1)
+Requirement already satisfied: pyproject-hooks==1.2.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 75)) (1.2.0)
+Requirement already satisfied: pytest==8.2.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 79)) (8.2.0)
+Requirement already satisfied: pytest-asyncio==1.1.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 85)) (1.1.0)
+Requirement already satisfied: pytest-cov==5.0.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 87)) (5.0.0)
+Requirement already satisfied: pytest-mock==3.14.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 89)) (3.14.1)
+Requirement already satisfied: python-dateutil==2.9.0.post0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 91)) (2.9.0.post0)
+Requirement already satisfied: python-dotenv==1.2.2 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 95)) (1.2.2)
+Requirement already satisfied: pyyaml==6.0.2 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 97)) (6.0.2)
+Requirement already satisfied: recurring-ical-events==3.8.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 101)) (3.8.0)
+Requirement already satisfied: requests==2.33.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 103)) (2.33.1)
+Requirement already satisfied: respx==0.22.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from respx[router]==0.22.0->-r ci-requirements.txt (line 105)) (0.22.0)
+Requirement already satisfied: ruff==0.12.4 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 107)) (0.12.4)
+Requirement already satisfied: six==1.17.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 109)) (1.17.0)
+Requirement already satisfied: starlette==0.47.3 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 111)) (0.47.3)
+Requirement already satisfied: tenacity==9.1.2 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 113)) (9.1.2)
+Requirement already satisfied: typing-extensions==4.15.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 115)) (4.15.0)
+Requirement already satisfied: typing-inspection==0.4.2 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 123)) (0.4.2)
+Requirement already satisfied: tzdata==2026.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 127)) (2026.1)
+Requirement already satisfied: urllib3==2.6.3 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 132)) (2.6.3)
+Requirement already satisfied: uvicorn==0.35.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 134)) (0.35.0)
+Requirement already satisfied: wheel==0.45.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 136)) (0.45.1)
+Requirement already satisfied: x-wr-timezone==2.0.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from -r ci-requirements.txt (line 140)) (2.0.1)
+Requirement already satisfied: pip>=22.2 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pip-tools==7.4.1->-r ci-requirements.txt (line 61)) (26.0.1)
+Requirement already satisfied: setuptools in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pip-tools==7.4.1->-r ci-requirements.txt (line 61)) (82.0.0)
+WARNING: respx 0.22.0 does not provide the extra 'router'
+Obtaining file:///home/alexey/LAN_Transcriber
+  Installing build dependencies: started
+  Installing build dependencies: finished with status 'done'
+  Checking if build backend supports build_editable: started
+  Checking if build backend supports build_editable: finished with status 'done'
+  Getting requirements to build editable: started
+  Getting requirements to build editable: finished with status 'done'
+  Preparing editable metadata (pyproject.toml): started
+  Preparing editable metadata (pyproject.toml): finished with status 'done'
+Requirement already satisfied: httpx in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (0.28.1)
+Requirement already satisfied: tenacity in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (9.1.2)
+Requirement already satisfied: prometheus_client>=0.19.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (0.25.0)
+Requirement already satisfied: anyio in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (4.13.0)
+Requirement already satisfied: fastapi in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (0.116.1)
+Requirement already satisfied: jinja2 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (3.1.6)
+Requirement already satisfied: python-multipart in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (0.0.22)
+Requirement already satisfied: redis in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (7.2.0)
+Requirement already satisfied: rq in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (2.6.1)
+Requirement already satisfied: pyyaml in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (6.0.2)
+Requirement already satisfied: pydantic-settings in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (2.10.1)
+Requirement already satisfied: rapidfuzz in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (3.14.3)
+Requirement already satisfied: icalendar>=6.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (6.3.1)
+Requirement already satisfied: recurring-ical-events>=3.6 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (3.8.0)
+Requirement already satisfied: pytest in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (8.2.0)
+Requirement already satisfied: pytest-asyncio in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (1.1.0)
+Requirement already satisfied: pytest-cov in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (5.0.0)
+Requirement already satisfied: pytest-mock in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (3.14.1)
+Requirement already satisfied: respx[router] in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (0.22.0)
+Requirement already satisfied: fonttools>=4.0 in /home/alexey/.local/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (4.62.1)
+Requirement already satisfied: brotli in /home/alexey/.local/lib/python3.11/site-packages (from lan-transcriber==0.1.0) (1.2.0)
+Requirement already satisfied: python-dateutil in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from icalendar>=6.0->lan-transcriber==0.1.0) (2.9.0.post0)
+Requirement already satisfied: tzdata in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from icalendar>=6.0->lan-transcriber==0.1.0) (2026.1)
+Requirement already satisfied: x-wr-timezone<3.0.0,>=1.0.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from recurring-ical-events>=3.6->lan-transcriber==0.1.0) (2.0.1)
+Requirement already satisfied: six>=1.5 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from python-dateutil->icalendar>=6.0->lan-transcriber==0.1.0) (1.17.0)
+Requirement already satisfied: click in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from x-wr-timezone<3.0.0,>=1.0.0->recurring-ical-events>=3.6->lan-transcriber==0.1.0) (8.3.2)
+Requirement already satisfied: idna>=2.8 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from anyio->lan-transcriber==0.1.0) (3.11)
+Requirement already satisfied: typing_extensions>=4.5 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from anyio->lan-transcriber==0.1.0) (4.15.0)
+Requirement already satisfied: starlette<0.48.0,>=0.40.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from fastapi->lan-transcriber==0.1.0) (0.47.3)
+Requirement already satisfied: pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from fastapi->lan-transcriber==0.1.0) (2.12.5)
+Requirement already satisfied: annotated-types>=0.6.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi->lan-transcriber==0.1.0) (0.7.0)
+Requirement already satisfied: pydantic-core==2.41.5 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi->lan-transcriber==0.1.0) (2.41.5)
+Requirement already satisfied: typing-inspection>=0.4.2 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi->lan-transcriber==0.1.0) (0.4.2)
+Requirement already satisfied: certifi in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from httpx->lan-transcriber==0.1.0) (2026.2.25)
+Requirement already satisfied: httpcore==1.* in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from httpx->lan-transcriber==0.1.0) (1.0.9)
+Requirement already satisfied: h11>=0.16 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from httpcore==1.*->httpx->lan-transcriber==0.1.0) (0.16.0)
+Requirement already satisfied: MarkupSafe>=2.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from jinja2->lan-transcriber==0.1.0) (3.0.3)
+Requirement already satisfied: python-dotenv>=0.21.0 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pydantic-settings->lan-transcriber==0.1.0) (1.2.2)
+Requirement already satisfied: iniconfig in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pytest->lan-transcriber==0.1.0) (2.3.0)
+Requirement already satisfied: packaging in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pytest->lan-transcriber==0.1.0) (26.0)
+Requirement already satisfied: pluggy<2.0,>=1.5 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from pytest->lan-transcriber==0.1.0) (1.6.0)
+Requirement already satisfied: coverage>=5.2.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from coverage[toml]>=5.2.1->pytest-cov->lan-transcriber==0.1.0) (7.13.5)
+WARNING: respx 0.22.0 does not provide the extra 'router'
+Requirement already satisfied: croniter in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from rq->lan-transcriber==0.1.0) (6.0.0)
+Requirement already satisfied: pytz>2021.1 in /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages (from croniter->rq->lan-transcriber==0.1.0) (2025.2)
+Building wheels for collected packages: lan-transcriber
+  Building editable for lan-transcriber (pyproject.toml): started
+  Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=6b8a43a0cbebbdee544af60a07d2922923c581507bafdc9515bd5348c09665e8
+  Stored in directory: /tmp/pip-ephem-wheel-cache-921fsoc4/wheels/3c/34/21/7d1a99d2a9e86cdb0d7c14d1c0d7dc5a97e0d170dff3df8fb1
+Successfully built lan-transcriber
+Installing collected packages: lan-transcriber
+  Attempting uninstall: lan-transcriber
+    Found existing installation: lan-transcriber 0.1.0
+    Uninstalling lan-transcriber-0.1.0:
+      Successfully uninstalled lan-transcriber-0.1.0
+Successfully installed lan-transcriber-0.1.0
+No broken requirements found.
 All checks passed!
 /home/alexey/.pyenv/versions/3.11.9/lib/python3.11/site-packages/pytest_asyncio/plugin.py:211: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
 The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
@@ -6,19 +122,20 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [  6%]
 ........................................................................ [ 12%]
 ........................................................................ [ 18%]
-........................................................................ [ 25%]
+........................................................................ [ 24%]
 ........................................................................ [ 31%]
 ........................................................................ [ 37%]
 ........................................................................ [ 43%]
-........................................................................ [ 50%]
+........................................................................ [ 49%]
 ........................................................................ [ 56%]
 ........................................................................ [ 62%]
 ........................................................................ [ 68%]
-................................................................s....... [ 75%]
+................................................................s....... [ 74%]
 ........................................................................ [ 81%]
 ........................................................................ [ 87%]
 ........................................................................ [ 93%]
-.......................................................................  [100%]
+........................................................................ [ 99%]
+...                                                                      [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -57,13 +174,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.11.9-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   14503      0   4868      0   100%
+TOTAL   14531      0   4874      0   100%
 
 64 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1150 passed, 3 skipped, 11 warnings in 106.83s (0:01:46)
+1154 passed, 3 skipped, 11 warnings in 104.59s (0:01:44)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -86,17 +203,17 @@ lan_transcriber/pipeline_steps/artifacts.py                19      0      0     
 lan_transcriber/pipeline_steps/diarization_quality.py     318      0    120      0   100%
 lan_transcriber/pipeline_steps/language.py                155      0     64      0   100%
 lan_transcriber/pipeline_steps/multilingual_asr.py        239      0     88      0   100%
-lan_transcriber/pipeline_steps/orchestrator.py           1257      0    366      0   100%
+lan_transcriber/pipeline_steps/orchestrator.py           1273      0    372      0   100%
 lan_transcriber/pipeline_steps/precheck.py                116      0     46      0   100%
 lan_transcriber/pipeline_steps/snippets.py                231      0     84      0   100%
-lan_transcriber/pipeline_steps/speaker_merge.py           207      0    104      0   100%
+lan_transcriber/pipeline_steps/speaker_merge.py           219      0    104      0   100%
 lan_transcriber/pipeline_steps/speaker_turns.py           267      0    134      0   100%
 lan_transcriber/pipeline_steps/summary_builder.py         276      0     98      0   100%
 lan_transcriber/runtime_paths.py                           21      0      4      0   100%
 lan_transcriber/torch_safe_globals.py                     126      0     40      0   100%
 lan_transcriber/utils.py                                   50      0     30      0   100%
 -----------------------------------------------------------------------------------------
-TOTAL                                                    4486      0   1550      0   100%
+TOTAL                                                    4514      0   1556      0   100%
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,338 +1,616 @@
-diff --git a/lan_app/templates/partials/recording_inspector_full_overview.html b/lan_app/templates/partials/recording_inspector_full_overview.html
-index b7aa892..c8ddd20 100644
---- a/lan_app/templates/partials/recording_inspector_full_overview.html
-+++ b/lan_app/templates/partials/recording_inspector_full_overview.html
-@@ -51,8 +51,8 @@
-         </div>
-         {% endfor %}
-       </div>
--      {% if preview.hidden_turn_count > 0 %}
--      <p class="text-xs text-slate-400 mt-3">{{ preview.hidden_turn_count }} more turns in the full transcript.</p>
-+      {% if preview.has_more %}
-+      <p class="text-xs text-slate-400 mt-3">More turns available in the full transcript.</p>
-       {% endif %}
-       {% else %}
-       <p class="text-sm text-slate-400 italic">Not available yet</p>
-diff --git a/lan_app/templates/partials/speaker_review_table.html b/lan_app/templates/partials/speaker_review_table.html
-index 71b5989..c63baa1 100644
---- a/lan_app/templates/partials/speaker_review_table.html
-+++ b/lan_app/templates/partials/speaker_review_table.html
-@@ -94,11 +94,12 @@
-                   data-testid="speaker-review-row-dialog">
-             <div class="flex items-center justify-between px-4 pt-3 pb-2 border-b border-slate-100 sticky top-0 bg-white">
-               <h4 class="text-xs font-bold text-slate-900">Speaker actions · {{ row.speaker }}</h4>
--              <form method="dialog" class="m-0">
--                <button type="submit" class="text-slate-400 hover:text-slate-700 inline-flex items-center" aria-label="Close">
--                  <span class="material-symbols-outlined text-lg">close</span>
--                </button>
--              </form>
-+              <button type="button"
-+                      class="text-slate-400 hover:text-slate-700 inline-flex items-center"
-+                      aria-label="Close"
-+                      data-speaker-actions-close>
-+                <span class="material-symbols-outlined text-lg">close</span>
-+              </button>
-             </div>
-             <div class="px-4 py-3 space-y-4 text-left overflow-y-auto" style="max-height: calc(85vh - 3rem);">
+diff --git a/lan_transcriber/pipeline_steps/orchestrator.py b/lan_transcriber/pipeline_steps/orchestrator.py
+index 76fe491..83d214a 100644
+--- a/lan_transcriber/pipeline_steps/orchestrator.py
++++ b/lan_transcriber/pipeline_steps/orchestrator.py
+@@ -997,10 +997,12 @@ def _resolve_pyannote_embedding_model(diariser: Diariser) -> EmbeddingModel | No
+         return None
  
-@@ -195,26 +196,128 @@
- {% else %}
- <p class="text-sm text-slate-400 italic">No speaker turns available yet. Run diarization first.</p>
- {% endif %}
-+<style>
-+/* Fallback styles for browsers without <dialog> showModal() support.
-+   When showModal() is unavailable we toggle the `open` attribute and
-+   the `.speaker-actions-dialog--fallback` class so the dialog still
-+   renders as a centered overlay with a plain backdrop. Browsers that
-+   do not recognise <dialog> at all (very old IE/legacy) still render
-+   its children because we force display:block when the class is set. */
-+dialog.speaker-actions-dialog--fallback {
-+  display: block;
-+  position: fixed;
-+  left: 50%;
-+  top: 50%;
-+  transform: translate(-50%, -50%);
-+  margin: 0;
-+  z-index: 60;
-+  background: #ffffff;
-+}
-+.speaker-actions-fallback-backdrop {
-+  position: fixed;
-+  inset: 0;
-+  background: rgba(15, 23, 42, 0.3);
-+  z-index: 59;
-+}
-+</style>
- <script>
- (function () {
-   if (window.__speakerActionsDialogWired) {
-     return;
-   }
-   window.__speakerActionsDialogWired = true;
-+
-+  function hasNativeModal(dialog) {
-+    return (
-+      dialog
-+      && typeof dialog.showModal === 'function'
-+      && typeof dialog.close === 'function'
-+    );
-+  }
-+
-+  function ensureFallbackBackdrop() {
-+    var backdrop = document.getElementById('speaker-actions-fallback-backdrop');
-+    if (!backdrop) {
-+      backdrop = document.createElement('div');
-+      backdrop.id = 'speaker-actions-fallback-backdrop';
-+      backdrop.className = 'speaker-actions-fallback-backdrop';
-+      backdrop.setAttribute('data-speaker-actions-backdrop', '');
-+      document.body.appendChild(backdrop);
-+    }
-+    return backdrop;
-+  }
-+
-+  function openDialog(dialog) {
-+    if (!dialog || dialog.open) {
-+      return;
-+    }
-+    try {
-+      if (hasNativeModal(dialog)) {
-+        dialog.showModal();
-+        return;
-+      }
-+    } catch (_err) {
-+      /* fall through to manual fallback */
-+    }
-+    dialog.classList.add('speaker-actions-dialog--fallback');
-+    dialog.setAttribute('open', '');
-+    ensureFallbackBackdrop().style.display = 'block';
-+  }
-+
-+  function closeDialog(dialog) {
-+    if (!dialog) {
-+      return;
-+    }
-+    if (dialog.classList.contains('speaker-actions-dialog--fallback')) {
-+      dialog.removeAttribute('open');
-+      dialog.classList.remove('speaker-actions-dialog--fallback');
-+      var backdrop = document.getElementById('speaker-actions-fallback-backdrop');
-+      if (backdrop) {
-+        backdrop.style.display = 'none';
-+      }
-+      return;
-+    }
-+    if (typeof dialog.close === 'function' && dialog.open) {
-+      dialog.close();
-+    } else if (dialog.open) {
-+      dialog.removeAttribute('open');
-+    }
-+  }
-+
-   document.addEventListener('click', function (event) {
-     var trigger = event.target.closest('[data-speaker-actions-open]');
-     if (trigger) {
--      var dialogId = trigger.getAttribute('data-speaker-actions-open');
--      var dialog = document.getElementById(dialogId);
--      if (dialog && typeof dialog.showModal === 'function' && !dialog.open) {
--        event.preventDefault();
--        dialog.showModal();
-+      event.preventDefault();
-+      openDialog(document.getElementById(trigger.getAttribute('data-speaker-actions-open')));
-+      return;
-+    }
-+    var closer = event.target.closest('[data-speaker-actions-close]');
-+    if (closer) {
-+      event.preventDefault();
-+      closeDialog(closer.closest('dialog.speaker-actions-dialog'));
-+      return;
-+    }
-+    if (event.target && event.target.hasAttribute && event.target.hasAttribute('data-speaker-actions-backdrop')) {
-+      var openFallback = document.querySelector('dialog.speaker-actions-dialog--fallback[open]');
-+      if (openFallback) {
-+        closeDialog(openFallback);
-       }
-       return;
-     }
-     var clickedDialog = event.target.closest('dialog.speaker-actions-dialog');
--    if (clickedDialog && event.target === clickedDialog) {
--      clickedDialog.close();
-+    if (clickedDialog && event.target === clickedDialog && !clickedDialog.classList.contains('speaker-actions-dialog--fallback')) {
-+      closeDialog(clickedDialog);
-+    }
-+  });
-+
-+  document.addEventListener('keydown', function (event) {
-+    if (event.key !== 'Escape') {
-+      return;
-+    }
-+    var openFallback = document.querySelector('dialog.speaker-actions-dialog--fallback[open]');
-+    if (openFallback) {
-+      event.preventDefault();
-+      closeDialog(openFallback);
-     }
-   });
- })();
-diff --git a/lan_app/ui_routes.py b/lan_app/ui_routes.py
-index d40f930..55a447c 100644
---- a/lan_app/ui_routes.py
-+++ b/lan_app/ui_routes.py
-@@ -1177,18 +1177,9 @@ def _full_page_overview_context(
-             cancel_value = f"{cancel_value} by {requested_by}"
-         focus_items.append({"label": "Stop requested", "value": cancel_value})
+     inference: Any = None
++    resolution_source: str | None = None
+     for attr in ("_embedding", "embedding"):
+         candidate = getattr(pipeline_model, attr, None)
+         if candidate is not None and callable(getattr(candidate, "crop", None)):
+             inference = candidate
++            resolution_source = "pipeline_attribute"
+             break
  
--    transcript_tab_ctx = _transcript_tab_context(recording_id, settings)
--    preview_turns = list(transcript_tab_ctx.get("turns") or [])[:15]
--    total_turn_count = int(transcript_tab_ctx.get("turn_count") or 0)
--    transcript_preview = {
--        "available": bool(preview_turns),
--        "turns": preview_turns,
--        "total_turn_count": total_turn_count,
--        "hidden_turn_count": max(total_turn_count - len(preview_turns), 0),
--        "full_transcript_href": _recording_detail_path(
--            recording_id, tab="transcript"
--        ),
--    }
-+    transcript_preview = _transcript_preview_context(
-+        recording_id, settings, limit=15
+     if inference is None:
+@@ -1013,6 +1015,12 @@ def _resolve_pyannote_embedding_model(diariser: Diariser) -> EmbeddingModel | No
+         if inference is None:
+             setattr(diariser, "_lan_speaker_embedding_unavailable", True)
+             return None
++        resolution_source = "standalone_inference"
++
++    _logger.info(
++        "speaker_merge: embedding model ready (source=%s)",
++        resolution_source,
 +    )
  
-     stages_list = list(pipeline_stages or [])
-     completed_stage_count = sum(
-@@ -1289,6 +1280,74 @@ def _full_page_overview_context(
-     }
+     def _embed(audio_path: Path, start: float, end: float):
+         try:
+@@ -1201,6 +1209,7 @@ def _write_diarization_metadata_artifact(
+     smoothing_result,
+     used_dummy_fallback: bool,
+     speaker_merges: dict[str, str] | None = None,
++    speaker_merge_diagnostics: dict[str, Any] | None = None,
+ ) -> None:
+     metadata = _diariser_runtime_metadata(diariser)
+     diariser_mode = _diariser_mode(diariser)
+@@ -1276,6 +1285,7 @@ def _write_diarization_metadata_artifact(
+     if profile_selection:
+         payload["profile_selection"] = profile_selection
+     payload["speaker_merges"] = dict(speaker_merges or {})
++    payload["speaker_merge_diagnostics"] = dict(speaker_merge_diagnostics or {})
+     atomic_write_json(artifacts.diarization_metadata_json_path, payload)
  
  
-+def _transcript_preview_context(
-+    recording_id: str,
-+    settings: AppSettings,
+@@ -3017,26 +3027,46 @@ async def run_pipeline(
+                 int(stats["segments"]),
+             )
+         speaker_merge_map: dict[str, str] = {}
+-        if (
+-            cfg.speaker_merge_enabled
+-            and not used_dummy_fallback
+-            and _diariser_mode(diariser) == "pyannote"
+-            and len({str(row.get("speaker") or "") for row in diar_segments}) >= 2
+-        ):
++        speaker_merge_diagnostics: dict[str, Any] = {
++            "embedding_model_available": False,
++            "speakers_found": [],
++            "centroids_computed": [],
++            "pairwise_scores": [],
++            "merges_applied": {},
++            "skipped_reason": None,
++        }
++        if not cfg.speaker_merge_enabled:
++            speaker_merge_diagnostics["skipped_reason"] = "disabled_by_config"
++        elif used_dummy_fallback:
++            speaker_merge_diagnostics["skipped_reason"] = "dummy_fallback"
++        elif _diariser_mode(diariser) != "pyannote":
++            speaker_merge_diagnostics["skipped_reason"] = "non_pyannote_diariser"
++        elif len({str(row.get("speaker") or "") for row in diar_segments}) < 2:
++            speaker_merge_diagnostics["skipped_reason"] = "single_speaker"
++        else:
+             embedding_model = _resolve_pyannote_embedding_model(diariser)
+             if embedding_model is None:
++                speaker_merge_diagnostics["skipped_reason"] = (
++                    "embedding_model_unavailable"
++                )
+                 _best_effort_step_log(
+                     step_log_callback,
+                     "speaker_merge skipped: embedding model unavailable",
+                 )
+             else:
+-                diar_segments, speaker_merge_map = merge_similar_speakers(
++                (
++                    diar_segments,
++                    speaker_merge_map,
++                    merge_run_diagnostics,
++                ) = merge_similar_speakers(
+                     diar_segments,
+                     audio_path=audio_path,
+                     embedding_model=embedding_model,
+                     similarity_threshold=cfg.speaker_merge_similarity_threshold,
+                     max_segments_per_speaker=cfg.speaker_merge_max_segments,
+                 )
++                speaker_merge_diagnostics.update(merge_run_diagnostics)
++                speaker_merge_diagnostics["skipped_reason"] = None
+                 if speaker_merge_map:
+                     _best_effort_step_log(
+                         step_log_callback,
+@@ -3086,6 +3116,7 @@ async def run_pipeline(
+             smoothing_result=smoothing_result,
+             used_dummy_fallback=used_dummy_fallback,
+             speaker_merges=speaker_merge_map,
++            speaker_merge_diagnostics=speaker_merge_diagnostics,
+         )
+ 
+         aliases = _load_aliases(cfg.speaker_db)
+diff --git a/lan_transcriber/pipeline_steps/speaker_merge.py b/lan_transcriber/pipeline_steps/speaker_merge.py
+index 4cc1794..976c4ae 100644
+--- a/lan_transcriber/pipeline_steps/speaker_merge.py
++++ b/lan_transcriber/pipeline_steps/speaker_merge.py
+@@ -320,6 +320,19 @@ def _resolve_merge_target(merge_map: dict[str, str], label: str) -> str:
+     return current
+ 
+ 
++def _empty_diagnostics(
 +    *,
-+    limit: int = 15,
++    embedding_model_available: bool,
 +) -> dict[str, Any]:
-+    """Cheap preview-only transcript context used by the Overview tab.
-+
-+    Unlike _transcript_tab_context, this helper stops processing as soon
-+    as ``limit`` non-empty turns have been collected and skips per-turn
-+    work (time range formatting, language lookups, copy_text generation)
-+    that the Overview preview does not render. It still reports
-+    ``has_more`` so the template can surface "more turns in the full
-+    transcript" hint without counting every remaining row.
-+    """
-+    transcript_path, _summary_path = _recording_derived_paths(
-+        recording_id, settings
-+    )
-+    speaker_turns_path = transcript_path.parent / "speaker_turns.json"
-+    transcript_payload = _load_json_dict(transcript_path)
-+    speaker_turns_raw = _load_json_list(speaker_turns_path)
-+    speaker_turns = [row for row in speaker_turns_raw if isinstance(row, dict)]
-+    if not speaker_turns:
-+        speaker_turns = _fallback_speaker_turns_from_transcript(transcript_payload)
-+
-+    speaker_name_map: dict[str, str] | None = None
-+    preview_turns: list[dict[str, str]] = []
-+    has_more = False
-+    for row in speaker_turns:
-+        text = str(row.get("text") or "").strip()
-+        if not text:
-+            continue
-+        if len(preview_turns) >= limit:
-+            has_more = True
-+            break
-+        if speaker_name_map is None:
-+            speaker_name_map = _recording_speaker_name_map(
-+                recording_id, settings=settings
-+            )
-+        speaker = _speaker_display_label(
-+            str(row.get("speaker") or "S1"),
-+            speaker_name_map=speaker_name_map,
-+        )
-+        try:
-+            parsed_start: float | None = float(row.get("start"))
-+        except (TypeError, ValueError):
-+            parsed_start = None
-+        timestamp = (
-+            _format_timestamp(parsed_start) if parsed_start is not None else ""
-+        )
-+        preview_turns.append(
-+            {
-+                "speaker": speaker,
-+                "timestamp": timestamp,
-+                "text": text,
-+            }
-+        )
-+
 +    return {
-+        "available": bool(preview_turns),
-+        "turns": preview_turns,
-+        "has_more": has_more,
-+        "full_transcript_href": _recording_detail_path(
-+            recording_id, tab="transcript"
-+        ),
++        "embedding_model_available": embedding_model_available,
++        "speakers_found": [],
++        "centroids_computed": [],
++        "pairwise_scores": [],
++        "merges_applied": {},
 +    }
 +
 +
- def _transcript_tab_context(recording_id: str, settings: AppSettings) -> dict[str, Any]:
-     transcript_path, _summary_path = _recording_derived_paths(recording_id, settings)
-     speaker_turns_path = transcript_path.parent / "speaker_turns.json"
-diff --git a/tests/test_cov_lan_app_ui_routes.py b/tests/test_cov_lan_app_ui_routes.py
-index 1f83980..d318d1a 100644
---- a/tests/test_cov_lan_app_ui_routes.py
-+++ b/tests/test_cov_lan_app_ui_routes.py
-@@ -1582,6 +1582,59 @@ def test_full_page_helpers_cover_overview_and_next_action_branches(
-     )
+ def merge_similar_speakers(
+     diar_segments: Sequence[dict[str, Any]],
+     *,
+@@ -329,20 +342,43 @@ def merge_similar_speakers(
+     max_segments_per_speaker: int = DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
+     segment_duration_sec: float = DEFAULT_SPEAKER_MERGE_SEGMENT_DURATION_SEC,
+     overlap_tolerance_sec: float = DEFAULT_SPEAKER_MERGE_OVERLAP_TOLERANCE_SEC,
+-) -> tuple[list[dict[str, Any]], dict[str, str]]:
++) -> tuple[list[dict[str, Any]], dict[str, str], dict[str, Any]]:
+     """Merge diarization speakers with similar voices that never overlap.
  
+-    Returns a tuple ``(updated_segments, merge_map)`` where ``merge_map`` is a
+-    mapping from the merged label to the kept label after transitive merges.
+-    When ``embedding_model`` is ``None`` the function is a no-op: it returns
+-    the original segments (as a new list) and an empty ``merge_map``.
++    Returns a tuple ``(updated_segments, merge_map, diagnostics)`` where
++    ``merge_map`` is a mapping from the merged label to the kept label after
++    transitive merges and ``diagnostics`` is a dict describing the inputs and
++    per-pair outcomes so operators can understand why speakers were or were
++    not merged. When ``embedding_model`` is ``None`` the function is a no-op:
++    it returns the original segments (as a new list), an empty ``merge_map``,
++    and a diagnostics dict with ``embedding_model_available=False``.
+     """
  
-+def test_transcript_preview_context_truncates_and_reports_has_more(
-+    tmp_path: Path,
-+) -> None:
-+    cfg = _cfg(tmp_path)
-+    derived = cfg.recordings_root / "rec-preview-1" / "derived"
-+    derived.mkdir(parents=True, exist_ok=True)
-+    (derived / "transcript.json").write_text(
-+        json.dumps({"text": "hello"}),
-+        encoding="utf-8",
+     original_segments = [dict(row) for row in diar_segments]
+     if embedding_model is None:
+-        return original_segments, {}
++        return (
++            original_segments,
++            {},
++            _empty_diagnostics(embedding_model_available=False),
++        )
++
++    speakers_found = sorted(
++        {
++            str(row.get("speaker") or "")
++            for row in original_segments
++            if str(row.get("speaker") or "")
++        }
 +    )
-+    turns_payload: list[dict[str, object]] = [
-+        {"start": "nope", "end": 0.5, "speaker": "S1", "text": "no timestamp"},
-+        {"start": 0.5, "end": 1.0, "speaker": "S2", "text": ""},
-+    ]
-+    for idx in range(4):
-+        turns_payload.append(
++    diagnostics: dict[str, Any] = {
++        "embedding_model_available": True,
++        "speakers_found": speakers_found,
++        "centroids_computed": [],
++        "pairwise_scores": [],
++        "merges_applied": {},
++    }
++
+     if not original_segments:
+-        return original_segments, {}
++        return original_segments, {}, diagnostics
+ 
+     centroids = extract_speaker_embeddings(
+         audio_path,
+@@ -351,8 +387,9 @@ def merge_similar_speakers(
+         max_segments_per_speaker=max_segments_per_speaker,
+         segment_duration_sec=segment_duration_sec,
+     )
++    diagnostics["centroids_computed"] = sorted(centroids.keys())
+     if len(centroids) < 2:
+-        return original_segments, {}
++        return original_segments, {}, diagnostics
+ 
+     pairs = compute_pairwise_similarity(centroids)
+     original_totals = _speaker_total_seconds(original_segments)
+@@ -360,11 +397,36 @@ def merge_similar_speakers(
+     merge_map: dict[str, str] = {}
+ 
+     for left_speaker, right_speaker, similarity in pairs:
+-        if similarity < similarity_threshold:
+-            break
+         left_target = _resolve_merge_target(merge_map, left_speaker)
+         right_target = _resolve_merge_target(merge_map, right_speaker)
+         if left_target == right_target:
++            diagnostics["pairwise_scores"].append(
++                {
++                    "speaker_a": left_speaker,
++                    "speaker_b": right_speaker,
++                    "similarity": float(similarity),
++                    "overlap": False,
++                    "action": "skipped_already_merged",
++                }
++            )
++            continue
++        if similarity < similarity_threshold:
++            _logger.info(
++                "speaker_merge: skip %s<->%s similarity=%.3f < threshold=%.3f",
++                left_speaker,
++                right_speaker,
++                similarity,
++                similarity_threshold,
++            )
++            diagnostics["pairwise_scores"].append(
++                {
++                    "speaker_a": left_speaker,
++                    "speaker_b": right_speaker,
++                    "similarity": float(similarity),
++                    "overlap": False,
++                    "action": "skipped_low_similarity",
++                }
++            )
+             continue
+         # Use a fresh copy of the original segments but with previously decided
+         # merges applied so overlap detection sees the post-merge world.
+@@ -380,6 +442,21 @@ def merge_similar_speakers(
+             overlap_segments,
+             tolerance_sec=overlap_tolerance_sec,
+         ):
++            _logger.info(
++                "speaker_merge: skip %s<->%s similarity=%.3f overlap=True",
++                left_speaker,
++                right_speaker,
++                similarity,
++            )
++            diagnostics["pairwise_scores"].append(
++                {
++                    "speaker_a": left_speaker,
++                    "speaker_b": right_speaker,
++                    "similarity": float(similarity),
++                    "overlap": True,
++                    "action": "skipped_overlap",
++                }
++            )
+             continue
+         left_total = totals.get(left_target, 0.0)
+         right_total = totals.get(right_target, 0.0)
+@@ -393,6 +470,15 @@ def merge_similar_speakers(
+         merge_map[merged] = kept
+         totals[kept] = totals.get(kept, 0.0) + totals.get(merged, 0.0)
+         totals[merged] = 0.0
++        diagnostics["pairwise_scores"].append(
 +            {
-+                "start": float(idx + 1),
-+                "end": float(idx + 2),
-+                "speaker": f"S{idx + 1}",
-+                "text": f"turn {idx}",
++                "speaker_a": left_speaker,
++                "speaker_b": right_speaker,
++                "similarity": float(similarity),
++                "overlap": False,
++                "action": "merged",
 +            }
 +        )
-+    (derived / "speaker_turns.json").write_text(
-+        json.dumps(turns_payload),
-+        encoding="utf-8",
+         _logger.info(
+             "Merged speaker %s into %s: similarity=%.3f, overlap=False, "
+             "%s_seconds=%.3f, %s_seconds=%.3f",
+@@ -406,7 +492,7 @@ def merge_similar_speakers(
+         )
+ 
+     if not merge_map:
+-        return original_segments, {}
++        return original_segments, {}, diagnostics
+ 
+     # Apply merges transitively to every segment.
+     updated_segments: list[dict[str, Any]] = []
+@@ -425,7 +511,8 @@ def merge_similar_speakers(
+         if final != label:
+             flattened_map[label] = final
+ 
+-    return updated_segments, flattened_map
++    diagnostics["merges_applied"] = dict(flattened_map)
++    return updated_segments, flattened_map, diagnostics
+ 
+ 
+ __all__ = [
+diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
+index 24c42ea..0e5584c 100644
+--- a/tasks/QUEUE.md
++++ b/tasks/QUEUE.md
+@@ -701,6 +701,6 @@ Queue (in order)
+ - Depends on: PR-TITLE-EDIT-01
+ 
+ 140) PR-SPEAKER-MERGE-DIAGNOSTICS-01: Add diagnostics to speaker merge step for debugging merge failures
+-- Status: TODO
++- Status: DONE
+ - Tasks file: tasks/PR-SPEAKER-MERGE-DIAGNOSTICS-01.md
+ - Depends on: PR-SPEAKER-MERGE-EMBEDDINGS-01
+diff --git a/tests/test_speaker_merge.py b/tests/test_speaker_merge.py
+index b2b3e00..824fe62 100644
+--- a/tests/test_speaker_merge.py
++++ b/tests/test_speaker_merge.py
+@@ -272,7 +272,7 @@ def test_merge_identical_embeddings_no_overlap() -> None:
+         {"A": embedding, "B": embedding},
+         {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -290,7 +290,7 @@ def test_no_merge_different_embeddings() -> None:
+         {"A": [1.0, 0.0], "B": [0.0, 1.0]},
+         {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -309,7 +309,7 @@ def test_no_merge_overlapping_speakers() -> None:
+         {"A": embedding, "B": embedding},
+         {"A": [(0.0, 5.0)], "B": [(2.0, 7.0)]},
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -333,7 +333,7 @@ def test_no_merge_below_threshold() -> None:
+         },
+         {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -361,7 +361,7 @@ def test_three_speakers_two_merge() -> None:
+             "C": [(12.0, 17.0)],
+         },
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -396,7 +396,7 @@ def test_transitive_merge_collapses_chain() -> None:
+             "C": [(27.0, 32.0)],
+         },
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -412,7 +412,7 @@ def test_merge_disabled_via_none_model() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=None,
+@@ -433,7 +433,7 @@ def test_merge_ignores_empty_speaker_labels_in_totals() -> None:
+         {"A": [1.0, 0.0], "B": [1.0, 0.0]},
+         {"A": [(6.0, 11.0)], "B": [(12.0, 17.0)]},
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -446,7 +446,7 @@ def test_merge_ignores_empty_speaker_labels_in_totals() -> None:
+ 
+ 
+ def test_merge_empty_segments_noop() -> None:
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         [],
+         audio_path=_AUDIO_PATH,
+         embedding_model=_make_embedding_model({}, {}),
+@@ -457,7 +457,7 @@ def test_merge_empty_segments_noop() -> None:
+ 
+ def test_merge_single_speaker_noop() -> None:
+     diar_segments = [_segment("A", 0.0, 5.0)]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_make_embedding_model(
+@@ -480,7 +480,7 @@ def test_merge_ties_break_lexicographically() -> None:
+         },
+         {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -502,7 +502,7 @@ def test_merge_larger_speaker_wins() -> None:
+         },
+         {"A": [(0.0, 1.0)], "B": [(2.0, 20.0)]},
+     )
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+@@ -526,7 +526,7 @@ def test_merge_accepts_objects_with_tolist() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -543,7 +543,7 @@ def test_merge_rejects_unconvertible_values() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -561,7 +561,7 @@ def test_merge_rejects_vectors_with_non_numeric_entries() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -581,7 +581,7 @@ def test_merge_accepts_two_d_single_row_embeddings() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -601,7 +601,7 @@ def test_merge_mean_pools_two_d_multi_row_embeddings() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -618,7 +618,7 @@ def test_merge_rejects_two_d_vectors_with_shape_mismatch() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -634,7 +634,7 @@ def test_merge_rejects_two_d_vectors_with_non_numeric_entries() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -650,7 +650,7 @@ def test_merge_rejects_two_d_vectors_with_empty_rows() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -666,7 +666,7 @@ def test_merge_rejects_two_d_vectors_with_nonfinite_pool_result() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    updated, merge_map = merge_similar_speakers(
++    updated, merge_map, _diag = merge_similar_speakers(
+         diar_segments,
+         audio_path=_AUDIO_PATH,
+         embedding_model=_model,
+@@ -674,6 +674,120 @@ def test_merge_rejects_two_d_vectors_with_nonfinite_pool_result() -> None:
+     assert merge_map == {}
+ 
+ 
++def test_diagnostics_low_similarity() -> None:
++    diar_segments = [
++        _segment("A", 0.0, 5.0),
++        _segment("B", 6.0, 11.0),
++    ]
++    sim = 0.75
++    complement = math.sqrt(1.0 - sim * sim)
++    model = _make_embedding_model(
++        {
++            "A": [1.0, 0.0],
++            "B": [sim, complement],
++        },
++        {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
 +    )
-+
-+    preview = ui_routes._transcript_preview_context(  # noqa: SLF001
-+        "rec-preview-1", cfg, limit=3
++    _updated, merge_map, diagnostics = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=model,
++        similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
 +    )
-+    assert preview["available"] is True
-+    assert preview["has_more"] is True
-+    assert len(preview["turns"]) == 3
-+    assert preview["turns"][0]["timestamp"] == ""
-+    assert preview["turns"][0]["text"] == "no timestamp"
-+    assert preview["turns"][1]["text"] == "turn 0"
-+    assert preview["full_transcript_href"].endswith("tab=transcript")
-+
-+    preview_all = ui_routes._transcript_preview_context(  # noqa: SLF001
-+        "rec-preview-1", cfg, limit=15
++    assert merge_map == {}
++    assert diagnostics["embedding_model_available"] is True
++    assert diagnostics["speakers_found"] == ["A", "B"]
++    assert diagnostics["centroids_computed"] == ["A", "B"]
++    actions = [entry["action"] for entry in diagnostics["pairwise_scores"]]
++    assert "skipped_low_similarity" in actions
++    low = next(
++        entry
++        for entry in diagnostics["pairwise_scores"]
++        if entry["action"] == "skipped_low_similarity"
 +    )
-+    assert preview_all["has_more"] is False
-+    assert len(preview_all["turns"]) == 5
++    assert low["similarity"] == pytest.approx(sim)
++    assert low["overlap"] is False
++    assert {low["speaker_a"], low["speaker_b"]} == {"A", "B"}
 +
-+    empty_preview = ui_routes._transcript_preview_context(  # noqa: SLF001
-+        "rec-preview-missing", cfg, limit=15
++
++def test_diagnostics_overlap() -> None:
++    diar_segments = [
++        _segment("A", 0.0, 5.0),
++        _segment("B", 2.0, 7.0),  # overlaps with A
++    ]
++    embedding = [1.0, 0.0]
++    model = _make_embedding_model(
++        {"A": embedding, "B": embedding},
++        {"A": [(0.0, 5.0)], "B": [(2.0, 7.0)]},
 +    )
-+    assert empty_preview["available"] is False
-+    assert empty_preview["turns"] == []
-+    assert empty_preview["has_more"] is False
++    _updated, merge_map, diagnostics = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=model,
++    )
++    assert merge_map == {}
++    actions = [entry["action"] for entry in diagnostics["pairwise_scores"]]
++    assert "skipped_overlap" in actions
++    overlap_entry = next(
++        entry
++        for entry in diagnostics["pairwise_scores"]
++        if entry["action"] == "skipped_overlap"
++    )
++    assert overlap_entry["overlap"] is True
++    assert overlap_entry["similarity"] == pytest.approx(1.0)
++    assert {overlap_entry["speaker_a"], overlap_entry["speaker_b"]} == {"A", "B"}
 +
 +
- def test_display_helpers_cover_timezone_duration_and_prepare_recording(
-     tmp_path: Path,
-     monkeypatch: pytest.MonkeyPatch,
++def test_diagnostics_merged() -> None:
++    diar_segments = [
++        _segment("A", 0.0, 5.0),
++        _segment("B", 6.0, 11.0),
++    ]
++    embedding = [1.0, 0.0]
++    model = _make_embedding_model(
++        {"A": embedding, "B": embedding},
++        {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
++    )
++    _updated, merge_map, diagnostics = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=model,
++    )
++    assert merge_map  # something was merged
++    merged_entries = [
++        entry
++        for entry in diagnostics["pairwise_scores"]
++        if entry["action"] == "merged"
++    ]
++    assert len(merged_entries) == 1
++    entry = merged_entries[0]
++    assert entry["overlap"] is False
++    assert entry["similarity"] == pytest.approx(1.0)
++    assert {entry["speaker_a"], entry["speaker_b"]} == {"A", "B"}
++    assert diagnostics["merges_applied"] == merge_map
++    assert diagnostics["centroids_computed"] == ["A", "B"]
++    assert diagnostics["speakers_found"] == ["A", "B"]
++
++
++def test_diagnostics_no_model() -> None:
++    diar_segments = [
++        _segment("A", 0.0, 5.0),
++        _segment("B", 6.0, 11.0),
++    ]
++    updated, merge_map, diagnostics = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=None,
++    )
++    assert merge_map == {}
++    assert updated == diar_segments
++    assert diagnostics["embedding_model_available"] is False
++    assert diagnostics["speakers_found"] == []
++    assert diagnostics["centroids_computed"] == []
++    assert diagnostics["pairwise_scores"] == []
++    assert diagnostics["merges_applied"] == {}
++
++
+ class _StubDiariser:
+     """Simple diariser stub used by orchestrator helper tests."""
+ 

--- a/lan_transcriber/pipeline_steps/orchestrator.py
+++ b/lan_transcriber/pipeline_steps/orchestrator.py
@@ -997,10 +997,12 @@ def _resolve_pyannote_embedding_model(diariser: Diariser) -> EmbeddingModel | No
         return None
 
     inference: Any = None
+    resolution_source: str | None = None
     for attr in ("_embedding", "embedding"):
         candidate = getattr(pipeline_model, attr, None)
         if candidate is not None and callable(getattr(candidate, "crop", None)):
             inference = candidate
+            resolution_source = "pipeline_attribute"
             break
 
     if inference is None:
@@ -1013,6 +1015,12 @@ def _resolve_pyannote_embedding_model(diariser: Diariser) -> EmbeddingModel | No
         if inference is None:
             setattr(diariser, "_lan_speaker_embedding_unavailable", True)
             return None
+        resolution_source = "standalone_inference"
+
+    _logger.info(
+        "speaker_merge: embedding model ready (source=%s)",
+        resolution_source,
+    )
 
     def _embed(audio_path: Path, start: float, end: float):
         try:
@@ -1201,6 +1209,7 @@ def _write_diarization_metadata_artifact(
     smoothing_result,
     used_dummy_fallback: bool,
     speaker_merges: dict[str, str] | None = None,
+    speaker_merge_diagnostics: dict[str, Any] | None = None,
 ) -> None:
     metadata = _diariser_runtime_metadata(diariser)
     diariser_mode = _diariser_mode(diariser)
@@ -1276,6 +1285,7 @@ def _write_diarization_metadata_artifact(
     if profile_selection:
         payload["profile_selection"] = profile_selection
     payload["speaker_merges"] = dict(speaker_merges or {})
+    payload["speaker_merge_diagnostics"] = dict(speaker_merge_diagnostics or {})
     atomic_write_json(artifacts.diarization_metadata_json_path, payload)
 
 
@@ -3017,26 +3027,46 @@ async def run_pipeline(
                 int(stats["segments"]),
             )
         speaker_merge_map: dict[str, str] = {}
-        if (
-            cfg.speaker_merge_enabled
-            and not used_dummy_fallback
-            and _diariser_mode(diariser) == "pyannote"
-            and len({str(row.get("speaker") or "") for row in diar_segments}) >= 2
-        ):
+        speaker_merge_diagnostics: dict[str, Any] = {
+            "embedding_model_available": False,
+            "speakers_found": [],
+            "centroids_computed": [],
+            "pairwise_scores": [],
+            "merges_applied": {},
+            "skipped_reason": None,
+        }
+        if not cfg.speaker_merge_enabled:
+            speaker_merge_diagnostics["skipped_reason"] = "disabled_by_config"
+        elif used_dummy_fallback:
+            speaker_merge_diagnostics["skipped_reason"] = "dummy_fallback"
+        elif _diariser_mode(diariser) != "pyannote":
+            speaker_merge_diagnostics["skipped_reason"] = "non_pyannote_diariser"
+        elif len({str(row.get("speaker") or "") for row in diar_segments}) < 2:
+            speaker_merge_diagnostics["skipped_reason"] = "single_speaker"
+        else:
             embedding_model = _resolve_pyannote_embedding_model(diariser)
             if embedding_model is None:
+                speaker_merge_diagnostics["skipped_reason"] = (
+                    "embedding_model_unavailable"
+                )
                 _best_effort_step_log(
                     step_log_callback,
                     "speaker_merge skipped: embedding model unavailable",
                 )
             else:
-                diar_segments, speaker_merge_map = merge_similar_speakers(
+                (
+                    diar_segments,
+                    speaker_merge_map,
+                    merge_run_diagnostics,
+                ) = merge_similar_speakers(
                     diar_segments,
                     audio_path=audio_path,
                     embedding_model=embedding_model,
                     similarity_threshold=cfg.speaker_merge_similarity_threshold,
                     max_segments_per_speaker=cfg.speaker_merge_max_segments,
                 )
+                speaker_merge_diagnostics.update(merge_run_diagnostics)
+                speaker_merge_diagnostics["skipped_reason"] = None
                 if speaker_merge_map:
                     _best_effort_step_log(
                         step_log_callback,
@@ -3086,6 +3116,7 @@ async def run_pipeline(
             smoothing_result=smoothing_result,
             used_dummy_fallback=used_dummy_fallback,
             speaker_merges=speaker_merge_map,
+            speaker_merge_diagnostics=speaker_merge_diagnostics,
         )
 
         aliases = _load_aliases(cfg.speaker_db)

--- a/lan_transcriber/pipeline_steps/speaker_merge.py
+++ b/lan_transcriber/pipeline_steps/speaker_merge.py
@@ -320,6 +320,19 @@ def _resolve_merge_target(merge_map: dict[str, str], label: str) -> str:
     return current
 
 
+def _empty_diagnostics(
+    *,
+    embedding_model_available: bool,
+) -> dict[str, Any]:
+    return {
+        "embedding_model_available": embedding_model_available,
+        "speakers_found": [],
+        "centroids_computed": [],
+        "pairwise_scores": [],
+        "merges_applied": {},
+    }
+
+
 def merge_similar_speakers(
     diar_segments: Sequence[dict[str, Any]],
     *,
@@ -329,20 +342,43 @@ def merge_similar_speakers(
     max_segments_per_speaker: int = DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
     segment_duration_sec: float = DEFAULT_SPEAKER_MERGE_SEGMENT_DURATION_SEC,
     overlap_tolerance_sec: float = DEFAULT_SPEAKER_MERGE_OVERLAP_TOLERANCE_SEC,
-) -> tuple[list[dict[str, Any]], dict[str, str]]:
+) -> tuple[list[dict[str, Any]], dict[str, str], dict[str, Any]]:
     """Merge diarization speakers with similar voices that never overlap.
 
-    Returns a tuple ``(updated_segments, merge_map)`` where ``merge_map`` is a
-    mapping from the merged label to the kept label after transitive merges.
-    When ``embedding_model`` is ``None`` the function is a no-op: it returns
-    the original segments (as a new list) and an empty ``merge_map``.
+    Returns a tuple ``(updated_segments, merge_map, diagnostics)`` where
+    ``merge_map`` is a mapping from the merged label to the kept label after
+    transitive merges and ``diagnostics`` is a dict describing the inputs and
+    per-pair outcomes so operators can understand why speakers were or were
+    not merged. When ``embedding_model`` is ``None`` the function is a no-op:
+    it returns the original segments (as a new list), an empty ``merge_map``,
+    and a diagnostics dict with ``embedding_model_available=False``.
     """
 
     original_segments = [dict(row) for row in diar_segments]
     if embedding_model is None:
-        return original_segments, {}
+        return (
+            original_segments,
+            {},
+            _empty_diagnostics(embedding_model_available=False),
+        )
+
+    speakers_found = sorted(
+        {
+            str(row.get("speaker") or "")
+            for row in original_segments
+            if str(row.get("speaker") or "")
+        }
+    )
+    diagnostics: dict[str, Any] = {
+        "embedding_model_available": True,
+        "speakers_found": speakers_found,
+        "centroids_computed": [],
+        "pairwise_scores": [],
+        "merges_applied": {},
+    }
+
     if not original_segments:
-        return original_segments, {}
+        return original_segments, {}, diagnostics
 
     centroids = extract_speaker_embeddings(
         audio_path,
@@ -351,8 +387,9 @@ def merge_similar_speakers(
         max_segments_per_speaker=max_segments_per_speaker,
         segment_duration_sec=segment_duration_sec,
     )
+    diagnostics["centroids_computed"] = sorted(centroids.keys())
     if len(centroids) < 2:
-        return original_segments, {}
+        return original_segments, {}, diagnostics
 
     pairs = compute_pairwise_similarity(centroids)
     original_totals = _speaker_total_seconds(original_segments)
@@ -360,11 +397,36 @@ def merge_similar_speakers(
     merge_map: dict[str, str] = {}
 
     for left_speaker, right_speaker, similarity in pairs:
-        if similarity < similarity_threshold:
-            break
         left_target = _resolve_merge_target(merge_map, left_speaker)
         right_target = _resolve_merge_target(merge_map, right_speaker)
         if left_target == right_target:
+            diagnostics["pairwise_scores"].append(
+                {
+                    "speaker_a": left_speaker,
+                    "speaker_b": right_speaker,
+                    "similarity": float(similarity),
+                    "overlap": False,
+                    "action": "skipped_already_merged",
+                }
+            )
+            continue
+        if similarity < similarity_threshold:
+            _logger.info(
+                "speaker_merge: skip %s<->%s similarity=%.3f < threshold=%.3f",
+                left_speaker,
+                right_speaker,
+                similarity,
+                similarity_threshold,
+            )
+            diagnostics["pairwise_scores"].append(
+                {
+                    "speaker_a": left_speaker,
+                    "speaker_b": right_speaker,
+                    "similarity": float(similarity),
+                    "overlap": False,
+                    "action": "skipped_low_similarity",
+                }
+            )
             continue
         # Use a fresh copy of the original segments but with previously decided
         # merges applied so overlap detection sees the post-merge world.
@@ -380,6 +442,21 @@ def merge_similar_speakers(
             overlap_segments,
             tolerance_sec=overlap_tolerance_sec,
         ):
+            _logger.info(
+                "speaker_merge: skip %s<->%s similarity=%.3f overlap=True",
+                left_speaker,
+                right_speaker,
+                similarity,
+            )
+            diagnostics["pairwise_scores"].append(
+                {
+                    "speaker_a": left_speaker,
+                    "speaker_b": right_speaker,
+                    "similarity": float(similarity),
+                    "overlap": True,
+                    "action": "skipped_overlap",
+                }
+            )
             continue
         left_total = totals.get(left_target, 0.0)
         right_total = totals.get(right_target, 0.0)
@@ -393,6 +470,15 @@ def merge_similar_speakers(
         merge_map[merged] = kept
         totals[kept] = totals.get(kept, 0.0) + totals.get(merged, 0.0)
         totals[merged] = 0.0
+        diagnostics["pairwise_scores"].append(
+            {
+                "speaker_a": left_speaker,
+                "speaker_b": right_speaker,
+                "similarity": float(similarity),
+                "overlap": False,
+                "action": "merged",
+            }
+        )
         _logger.info(
             "Merged speaker %s into %s: similarity=%.3f, overlap=False, "
             "%s_seconds=%.3f, %s_seconds=%.3f",
@@ -406,7 +492,7 @@ def merge_similar_speakers(
         )
 
     if not merge_map:
-        return original_segments, {}
+        return original_segments, {}, diagnostics
 
     # Apply merges transitively to every segment.
     updated_segments: list[dict[str, Any]] = []
@@ -425,7 +511,8 @@ def merge_similar_speakers(
         if final != label:
             flattened_map[label] = final
 
-    return updated_segments, flattened_map
+    diagnostics["merges_applied"] = dict(flattened_map)
+    return updated_segments, flattened_map, diagnostics
 
 
 __all__ = [

--- a/tasks/QUEUE.md
+++ b/tasks/QUEUE.md
@@ -701,6 +701,6 @@ Queue (in order)
 - Depends on: PR-TITLE-EDIT-01
 
 140) PR-SPEAKER-MERGE-DIAGNOSTICS-01: Add diagnostics to speaker merge step for debugging merge failures
-- Status: TODO
+- Status: DONE
 - Tasks file: tasks/PR-SPEAKER-MERGE-DIAGNOSTICS-01.md
 - Depends on: PR-SPEAKER-MERGE-EMBEDDINGS-01

--- a/tests/test_speaker_merge.py
+++ b/tests/test_speaker_merge.py
@@ -272,7 +272,7 @@ def test_merge_identical_embeddings_no_overlap() -> None:
         {"A": embedding, "B": embedding},
         {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -290,7 +290,7 @@ def test_no_merge_different_embeddings() -> None:
         {"A": [1.0, 0.0], "B": [0.0, 1.0]},
         {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -309,7 +309,7 @@ def test_no_merge_overlapping_speakers() -> None:
         {"A": embedding, "B": embedding},
         {"A": [(0.0, 5.0)], "B": [(2.0, 7.0)]},
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -333,7 +333,7 @@ def test_no_merge_below_threshold() -> None:
         },
         {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -361,7 +361,7 @@ def test_three_speakers_two_merge() -> None:
             "C": [(12.0, 17.0)],
         },
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -396,7 +396,7 @@ def test_transitive_merge_collapses_chain() -> None:
             "C": [(27.0, 32.0)],
         },
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -412,7 +412,7 @@ def test_merge_disabled_via_none_model() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=None,
@@ -433,7 +433,7 @@ def test_merge_ignores_empty_speaker_labels_in_totals() -> None:
         {"A": [1.0, 0.0], "B": [1.0, 0.0]},
         {"A": [(6.0, 11.0)], "B": [(12.0, 17.0)]},
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -446,7 +446,7 @@ def test_merge_ignores_empty_speaker_labels_in_totals() -> None:
 
 
 def test_merge_empty_segments_noop() -> None:
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         [],
         audio_path=_AUDIO_PATH,
         embedding_model=_make_embedding_model({}, {}),
@@ -457,7 +457,7 @@ def test_merge_empty_segments_noop() -> None:
 
 def test_merge_single_speaker_noop() -> None:
     diar_segments = [_segment("A", 0.0, 5.0)]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_make_embedding_model(
@@ -480,7 +480,7 @@ def test_merge_ties_break_lexicographically() -> None:
         },
         {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -502,7 +502,7 @@ def test_merge_larger_speaker_wins() -> None:
         },
         {"A": [(0.0, 1.0)], "B": [(2.0, 20.0)]},
     )
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=model,
@@ -526,7 +526,7 @@ def test_merge_accepts_objects_with_tolist() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
@@ -543,7 +543,7 @@ def test_merge_rejects_unconvertible_values() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
@@ -561,7 +561,7 @@ def test_merge_rejects_vectors_with_non_numeric_entries() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
@@ -581,7 +581,7 @@ def test_merge_accepts_two_d_single_row_embeddings() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
@@ -601,7 +601,7 @@ def test_merge_mean_pools_two_d_multi_row_embeddings() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
@@ -618,7 +618,7 @@ def test_merge_rejects_two_d_vectors_with_shape_mismatch() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
@@ -634,7 +634,7 @@ def test_merge_rejects_two_d_vectors_with_non_numeric_entries() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
@@ -650,7 +650,7 @@ def test_merge_rejects_two_d_vectors_with_empty_rows() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
@@ -666,12 +666,126 @@ def test_merge_rejects_two_d_vectors_with_nonfinite_pool_result() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    updated, merge_map = merge_similar_speakers(
+    updated, merge_map, _diag = merge_similar_speakers(
         diar_segments,
         audio_path=_AUDIO_PATH,
         embedding_model=_model,
     )
     assert merge_map == {}
+
+
+def test_diagnostics_low_similarity() -> None:
+    diar_segments = [
+        _segment("A", 0.0, 5.0),
+        _segment("B", 6.0, 11.0),
+    ]
+    sim = 0.75
+    complement = math.sqrt(1.0 - sim * sim)
+    model = _make_embedding_model(
+        {
+            "A": [1.0, 0.0],
+            "B": [sim, complement],
+        },
+        {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
+    )
+    _updated, merge_map, diagnostics = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=model,
+        similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+    )
+    assert merge_map == {}
+    assert diagnostics["embedding_model_available"] is True
+    assert diagnostics["speakers_found"] == ["A", "B"]
+    assert diagnostics["centroids_computed"] == ["A", "B"]
+    actions = [entry["action"] for entry in diagnostics["pairwise_scores"]]
+    assert "skipped_low_similarity" in actions
+    low = next(
+        entry
+        for entry in diagnostics["pairwise_scores"]
+        if entry["action"] == "skipped_low_similarity"
+    )
+    assert low["similarity"] == pytest.approx(sim)
+    assert low["overlap"] is False
+    assert {low["speaker_a"], low["speaker_b"]} == {"A", "B"}
+
+
+def test_diagnostics_overlap() -> None:
+    diar_segments = [
+        _segment("A", 0.0, 5.0),
+        _segment("B", 2.0, 7.0),  # overlaps with A
+    ]
+    embedding = [1.0, 0.0]
+    model = _make_embedding_model(
+        {"A": embedding, "B": embedding},
+        {"A": [(0.0, 5.0)], "B": [(2.0, 7.0)]},
+    )
+    _updated, merge_map, diagnostics = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=model,
+    )
+    assert merge_map == {}
+    actions = [entry["action"] for entry in diagnostics["pairwise_scores"]]
+    assert "skipped_overlap" in actions
+    overlap_entry = next(
+        entry
+        for entry in diagnostics["pairwise_scores"]
+        if entry["action"] == "skipped_overlap"
+    )
+    assert overlap_entry["overlap"] is True
+    assert overlap_entry["similarity"] == pytest.approx(1.0)
+    assert {overlap_entry["speaker_a"], overlap_entry["speaker_b"]} == {"A", "B"}
+
+
+def test_diagnostics_merged() -> None:
+    diar_segments = [
+        _segment("A", 0.0, 5.0),
+        _segment("B", 6.0, 11.0),
+    ]
+    embedding = [1.0, 0.0]
+    model = _make_embedding_model(
+        {"A": embedding, "B": embedding},
+        {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
+    )
+    _updated, merge_map, diagnostics = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=model,
+    )
+    assert merge_map  # something was merged
+    merged_entries = [
+        entry
+        for entry in diagnostics["pairwise_scores"]
+        if entry["action"] == "merged"
+    ]
+    assert len(merged_entries) == 1
+    entry = merged_entries[0]
+    assert entry["overlap"] is False
+    assert entry["similarity"] == pytest.approx(1.0)
+    assert {entry["speaker_a"], entry["speaker_b"]} == {"A", "B"}
+    assert diagnostics["merges_applied"] == merge_map
+    assert diagnostics["centroids_computed"] == ["A", "B"]
+    assert diagnostics["speakers_found"] == ["A", "B"]
+
+
+def test_diagnostics_no_model() -> None:
+    diar_segments = [
+        _segment("A", 0.0, 5.0),
+        _segment("B", 6.0, 11.0),
+    ]
+    updated, merge_map, diagnostics = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=None,
+    )
+    assert merge_map == {}
+    assert updated == diar_segments
+    assert diagnostics["embedding_model_available"] is False
+    assert diagnostics["speakers_found"] == []
+    assert diagnostics["centroids_computed"] == []
+    assert diagnostics["pairwise_scores"] == []
+    assert diagnostics["merges_applied"] == {}
 
 
 class _StubDiariser:


### PR DESCRIPTION
## Summary
- `merge_similar_speakers` now returns `(segments, merge_map, diagnostics)`. The diagnostics dict captures `embedding_model_available`, `speakers_found`, `centroids_computed`, a `pairwise_scores` list with similarity/overlap/action per pair, and the applied `merges_applied` map so operators can see exactly why merges were or were not performed.
- Orchestrator wires the diagnostics through `diarization_metadata.json` under `speaker_merge_diagnostics`, records a `skipped_reason` when the merge step is skipped entirely (disabled, dummy fallback, non-pyannote, single speaker, embedding model unavailable), and keeps the legacy `speaker_merges` key for backward compatibility.
- `_resolve_pyannote_embedding_model` now logs an INFO message with the resolution `source` (`pipeline_attribute` or `standalone_inference`) whenever the embedding model is successfully resolved.
- Tests: all existing `merge_similar_speakers` unit tests updated for the new 3-tuple return; four new tests added covering low-similarity, overlap, merged, and no-model diagnostic paths.

## PR metadata
- **PR_ID:** PR-SPEAKER-MERGE-DIAGNOSTICS-01
- **TASK_FILE:** tasks/PR-SPEAKER-MERGE-DIAGNOSTICS-01.md
- **Branch:** pr-speaker-merge-diagnostics-01

## How verified
- `bash scripts/ci.sh` -> exit 0, 1154 passed, 3 skipped, 100% statement + branch coverage.
- `bash scripts/make-review-artifacts.sh` -> refreshed `artifacts/ci.log` and `artifacts/pr.patch`.

## Artifacts
- artifacts/ci.log
- artifacts/pr.patch

## Test plan
- [ ] After processing a recording, open `diarization_metadata.json` and verify the new `speaker_merge_diagnostics` block contains `embedding_model_available`, `speakers_found`, `centroids_computed`, `pairwise_scores`, and `merges_applied`.
- [ ] Confirm `speaker_merges` (legacy map) still matches `speaker_merge_diagnostics.merges_applied`.
- [ ] For a recording where the embedding model fails to load, verify `skipped_reason == "embedding_model_unavailable"` and `embedding_model_available == False`.
- [ ] Tail worker logs and confirm the new INFO log `speaker_merge: embedding model ready (source=...)` appears once per diariser instance.

@codex review