### PR TITLE
PR-ARTIFACT-SINGLE-WRITER-01: consolidate derived artifact payload builders

### DIFF
--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -8,18 +8,18 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [ 18%]
 ........................................................................ [ 24%]
 ........................................................................ [ 30%]
-........................................................................ [ 37%]
+........................................................................ [ 36%]
 ........................................................................ [ 43%]
 ........................................................................ [ 49%]
 ........................................................................ [ 55%]
 ........................................................................ [ 61%]
 ........................................................................ [ 67%]
-...................................................................s.... [ 74%]
+......................................................................s. [ 73%]
 ........................................................................ [ 80%]
 ........................................................................ [ 86%]
 ........................................................................ [ 92%]
 ........................................................................ [ 98%]
-.............                                                            [100%]
+................                                                         [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -58,13 +58,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.11.9-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   14583      0   4894      0   100%
+TOTAL   14566      0   4882      0   100%
 
 64 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1164 passed, 3 skipped, 11 warnings in 106.69s (0:01:46)
+1167 passed, 3 skipped, 11 warnings in 104.35s (0:01:44)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -87,7 +87,7 @@ lan_transcriber/pipeline_steps/artifacts.py                19      0      0     
 lan_transcriber/pipeline_steps/diarization_quality.py     318      0    120      0   100%
 lan_transcriber/pipeline_steps/language.py                155      0     64      0   100%
 lan_transcriber/pipeline_steps/multilingual_asr.py        239      0     88      0   100%
-lan_transcriber/pipeline_steps/orchestrator.py           1291      0    380      0   100%
+lan_transcriber/pipeline_steps/orchestrator.py           1298      0    380      0   100%
 lan_transcriber/pipeline_steps/precheck.py                116      0     46      0   100%
 lan_transcriber/pipeline_steps/snippets.py                231      0     84      0   100%
 lan_transcriber/pipeline_steps/speaker_merge.py           219      0    104      0   100%
@@ -97,7 +97,7 @@ lan_transcriber/runtime_paths.py                           21      0      4     
 lan_transcriber/torch_safe_globals.py                     126      0     40      0   100%
 lan_transcriber/utils.py                                   50      0     30      0   100%
 -----------------------------------------------------------------------------------------
-TOTAL                                                    4532      0   1564      0   100%
+TOTAL                                                    4539      0   1564      0   100%
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%
@@ -133,7 +133,7 @@ lan_app/ui.py                         59      0     10      0   100%
 lan_app/ui_routes.py                2670      0   1018      0   100%
 lan_app/uploads.py                    79      0     14      0   100%
 lan_app/worker.py                     28      0      2      0   100%
-lan_app/worker_tasks.py             1744      0    508      0   100%
+lan_app/worker_tasks.py             1720      0    496      0   100%
 lan_app/workers.py                    10      0      0      0   100%
 --------------------------------------------------------------------
-TOTAL                              10051      0   3330      0   100%
+TOTAL                              10027      0   3318      0   100%

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,377 +1,567 @@
+diff --git a/lan_app/worker_tasks.py b/lan_app/worker_tasks.py
+index 743c282..6778056 100644
+--- a/lan_app/worker_tasks.py
++++ b/lan_app/worker_tasks.py
+@@ -2574,77 +2574,23 @@ def _build_diarization_metadata_payload(
+     speaker_merges: dict[str, str] | None = None,
+     speaker_merge_diagnostics: dict[str, Any] | None = None,
+ ) -> dict[str, Any]:
+-    diariser_mode = str(runtime.get("mode") or "unknown").strip().lower() or "unknown"
+-    effective_hints = runtime.get("effective_hints")
+-    if not isinstance(effective_hints, dict):
+-        effective_hints = {}
+-    initial_hints = runtime.get("initial_hints")
+-    if not isinstance(initial_hints, dict):
+-        initial_hints = {}
+-    profile_selection = runtime.get("profile_selection")
+-    if not isinstance(profile_selection, dict):
+-        profile_selection = {}
+-    selected_profile = str(
+-        profile_selection.get("selected_profile")
+-        or runtime.get("selected_profile")
+-        or runtime.get("initial_profile")
+-        or runtime.get("diarization_profile")
+-        or cfg.diarization_profile
++    """Thin wrapper that delegates to the orchestrator's shared builder.
++
++    PR-ARTIFACT-SINGLE-WRITER-01 consolidated the diarization metadata
++    payload construction into a single source of truth in
++    ``lan_transcriber.pipeline_steps.orchestrator``. The wrapper is kept
++    so existing tests that reference ``worker_tasks._build_diarization_metadata_payload``
++    continue to hit the same code path the production pipeline uses.
++    """
++
++    return pipeline_orchestrator._build_diarization_metadata_payload(  # noqa: SLF001
++        runtime=runtime,
++        cfg=cfg,
++        smoothing_result=smoothing_result,
++        used_dummy_fallback=bool(runtime.get("used_dummy_fallback", False)),
++        speaker_merges=speaker_merges,
++        speaker_merge_diagnostics=speaker_merge_diagnostics,
+     )
+-    initial_metrics = profile_selection.get("initial_metrics")
+-    if not isinstance(initial_metrics, dict):
+-        initial_metrics = {}
+-    payload: dict[str, Any] = {
+-        "version": 1,
+-        "mode": diariser_mode,
+-        "degraded": bool(runtime.get("used_dummy_fallback")) or diariser_mode not in {"pyannote", "unknown"},
+-        "diarization_profile": str(runtime.get("diarization_profile") or cfg.diarization_profile),
+-        "requested_profile": str(
+-            runtime.get("requested_profile")
+-            or runtime.get("diarization_profile")
+-            or cfg.diarization_profile
+-        ),
+-        "effective_device": str(runtime.get("effective_device") or cfg.diarization_device),
+-        "scheduler_mode": str(runtime.get("scheduler_mode") or cfg.gpu_scheduler_mode),
+-        "scheduler_reason": runtime.get("scheduler_reason"),
+-        "initial_profile": str(runtime.get("initial_profile") or cfg.diarization_profile),
+-        "selected_profile": selected_profile,
+-        "selected_result": str(profile_selection.get("selected_result") or "initial_pass"),
+-        "auto_profile_enabled": bool(runtime.get("auto_profile_enabled", False)),
+-        "profile_override_reason": runtime.get("override_reason"),
+-        "hints_applied": effective_hints,
+-        "dialog_retry_attempted": bool(
+-            profile_selection.get(
+-                "dialog_retry_attempted",
+-                runtime.get("dialog_retry_used", False),
+-            )
+-        ),
+-        "dialog_retry_used": bool(runtime.get("dialog_retry_used", False)),
+-        "speaker_count_before_retry": runtime.get("speaker_count_before_retry"),
+-        "speaker_count_after_retry": runtime.get("speaker_count_after_retry"),
+-        "initial_speaker_count": initial_metrics.get(
+-            "speaker_count",
+-            runtime.get("speaker_count_before_retry"),
+-        ),
+-        "initial_top_two_coverage": initial_metrics.get("top_two_coverage"),
+-        "used_dummy_fallback": bool(runtime.get("used_dummy_fallback", False)),
+-        "smoothing_applied": bool(diariser_mode == "pyannote" and not runtime.get("used_dummy_fallback")),
+-        "merge_gap_seconds": cfg.diarization_merge_gap_seconds,
+-        "min_turn_seconds": cfg.diarization_min_turn_seconds,
+-        "speaker_count_before_smoothing": smoothing_result.speaker_count_before,
+-        "speaker_count_after_smoothing": smoothing_result.speaker_count_after,
+-        "turn_count_before_smoothing": smoothing_result.turn_count_before,
+-        "turn_count_after_smoothing": smoothing_result.turn_count_after,
+-        "adjacent_merges": smoothing_result.adjacent_merges,
+-        "micro_turn_absorptions": smoothing_result.micro_turn_absorptions,
+-    }
+-    if initial_hints != effective_hints:
+-        payload["initial_hints"] = initial_hints
+-    if profile_selection:
+-        payload["profile_selection"] = profile_selection
+-    payload["speaker_merges"] = dict(speaker_merges or {})
+-    payload["speaker_merge_diagnostics"] = dict(speaker_merge_diagnostics or {})
+-    return payload
+ 
+ 
+ def _stage_sanitize_audio(ctx: _PipelineExecutionContext) -> _StageResult:
+@@ -3570,28 +3516,30 @@ def _stage_export_artifacts(ctx: _PipelineExecutionContext) -> _StageResult:
+         ],
+         ctx.pipeline_settings.merge_similar,
+     )
+-    transcript_payload = pipeline_orchestrator._base_transcript_payload(
+-        recording_id=ctx.recording_id,
+-        language=language_info,
+-        dominant_language=str(ctx.language_payload.get("dominant_language") or "unknown"),
+-        language_distribution=dict(ctx.language_payload.get("language_distribution") or {}),
+-        language_spans=list(ctx.language_payload.get("language_spans") or []),
+-        target_summary_language=summary_lang,
+-        transcript_language_override=ctx.transcript_language_override,
+-        calendar_title=ctx.calendar_title,
+-        calendar_attendees=ctx.calendar_attendees,
+-        segments=language_segments,
+-        speakers=sorted(
+-            {
+-                aliases.get(str(turn.get("speaker") or "S1"), str(turn.get("speaker") or "S1"))
+-                for turn in ctx.speaker_turns
+-            }
++    transcript_payload = pipeline_orchestrator._finalize_transcript_payload(
++        pipeline_orchestrator._base_transcript_payload(
++            recording_id=ctx.recording_id,
++            language=language_info,
++            dominant_language=str(ctx.language_payload.get("dominant_language") or "unknown"),
++            language_distribution=dict(ctx.language_payload.get("language_distribution") or {}),
++            language_spans=list(ctx.language_payload.get("language_spans") or []),
++            target_summary_language=summary_lang,
++            transcript_language_override=ctx.transcript_language_override,
++            calendar_title=ctx.calendar_title,
++            calendar_attendees=ctx.calendar_attendees,
++            segments=language_segments,
++            speakers=sorted(
++                {
++                    aliases.get(str(turn.get("speaker") or "S1"), str(turn.get("speaker") or "S1"))
++                    for turn in ctx.speaker_turns
++                }
++            ),
++            text=ctx.clean_text,
+         ),
+-        text=ctx.clean_text,
++        speaker_lines=speaker_lines,
++        asr_execution=ctx.asr_execution,
++        review=ctx.language_payload.get("review") or {},
+     )
+-    transcript_payload["speaker_lines"] = speaker_lines
+-    transcript_payload["multilingual_asr"] = dict(ctx.asr_execution)
+-    transcript_payload["review"] = dict(ctx.language_payload.get("review") or {})
+     atomic_write_text(ctx.artifacts.recording_artifacts.transcript_txt_path, ctx.clean_text)
+     atomic_write_json(ctx.artifacts.recording_artifacts.transcript_json_path, transcript_payload)
+     atomic_write_json(ctx.artifacts.recording_artifacts.segments_json_path, ctx.diarization_segments)
 diff --git a/lan_transcriber/pipeline_steps/orchestrator.py b/lan_transcriber/pipeline_steps/orchestrator.py
-index 83d214a..71f79f2 100644
+index 71f79f2..4e625b6 100644
 --- a/lan_transcriber/pipeline_steps/orchestrator.py
 +++ b/lan_transcriber/pipeline_steps/orchestrator.py
-@@ -45,7 +45,10 @@ from ..metrics import error_rate_total, p95_latency_seconds
- from ..models import SpeakerSegment, TranscriptResult
- from ..native_fixups import ensure_ctranslate2_no_execstack
- from ..torch_safe_globals import (
-+    diarization_safe_globals_for_torch_load,
-+    import_trusted_diarization_symbol,
-     omegaconf_safe_globals_for_torch_load,
-+    unsupported_global_diarization_fqn_from_error,
-     unsupported_global_omegaconf_fqn_from_error,
- )
- from .language import analyse_languages, resolve_target_summary_language, segment_language
-@@ -944,10 +947,19 @@ def _diariser_pipeline_model(diariser: Diariser) -> Any | None:
+@@ -1246,75 +1246,108 @@ async def _maybe_retry_dialog_diarization(
+     return retry_result if winner_is_retry else diarization
  
  
- _DEFAULT_SPEAKER_EMBEDDING_MODEL = "pyannote/wespeaker-voxceleb-resnet34-LM"
-+_SPEAKER_EMBEDDING_SAFE_GLOBAL_ATTEMPTS = 3
- 
- 
--def _build_pyannote_inference(model_or_name: Any) -> Any | None:
--    """Construct a pyannote ``Inference`` wrapper, returning ``None`` on failure."""
-+def _build_pyannote_inference(
-+    model_or_name: Any, *, device: str | None = None
-+) -> Any | None:
-+    """Construct a pyannote ``Inference`` wrapper, returning ``None`` on failure.
+-def _write_diarization_metadata_artifact(
++# -----------------------------------------------------------------------------
++# Shared artifact payload builders (PR-ARTIFACT-SINGLE-WRITER-01)
++#
++# These helpers exist so that the legacy monolithic ``run_pipeline`` path and
++# the stage-based execution in ``lan_app.worker_tasks`` build derived JSON
++# artifact payloads from a single source. Before PR-ARTIFACT-SINGLE-WRITER-01,
++# ``lan_app.worker_tasks`` had its own parallel implementations that silently
++# dropped fields when orchestrator payloads gained new keys (see
++# PR-SPEAKER-MERGE-DIAGNOSTICS-HOTFIX-01). Always extend these shared builders
++# when adding fields, and call them from both the orchestrator and the worker.
++#
++# Conflict matrix of derived artifacts that can be written by both paths:
++#   diarization_metadata.json : stage path writes in ``_stage_speaker_turns``;
++#                               legacy path writes in ``_write_diarization_metadata_artifact``.
++#                               Shared builder: ``_build_diarization_metadata_payload``.
++#   transcript.json           : stage path writes in ``_stage_export_artifacts``;
++#                               legacy path writes at the end of ``run_pipeline``.
++#                               Shared builder: ``_finalize_transcript_payload``.
++#   segments.json             : list payload copied verbatim from ``diar_segments``.
++#   speaker_turns.json        : list payload copied verbatim from smoothed turns.
++#   summary.json              : dict payload produced by ``build_summary_payload`` or
++#                               ``_build_structured_summary_payload`` (already shared).
++#   transcript.txt            : plain text copy of ``clean_text``.
++#   metrics.json              : independent per-path (legacy: run_pipeline; stage:
++#                               ``_stage_metrics``). Not a dual-write conflict.
++# -----------------------------------------------------------------------------
 +
-+    Loading the wespeaker checkpoint goes through ``torch.load`` which now
-+    defaults to ``weights_only=True``. Wrap the constructor in the same trusted
-+    safe-globals context that the diarization pipeline loader uses, with the
-+    same bounded retry on ``Unsupported global`` errors.
++
++def _build_diarization_metadata_payload(
+     *,
+-    artifacts,
+-    diariser: Diariser,
++    runtime: dict[str, Any],
+     cfg: Settings,
+     smoothing_result,
+     used_dummy_fallback: bool,
+     speaker_merges: dict[str, str] | None = None,
+     speaker_merge_diagnostics: dict[str, Any] | None = None,
+-) -> None:
+-    metadata = _diariser_runtime_metadata(diariser)
+-    diariser_mode = _diariser_mode(diariser)
+-    effective_hints = metadata.get("effective_hints")
++) -> dict[str, Any]:
++    """Build the ``diarization_metadata.json`` payload from a runtime dict.
++
++    This is the single source of truth for diarization metadata fields.
++    Both ``_write_diarization_metadata_artifact`` (legacy monolithic path)
++    and ``lan_app.worker_tasks._stage_speaker_turns`` (stage-based production
++    path) call this function so that payload fields stay in sync.
 +    """
-     try:
-         from pyannote.audio import Inference  # type: ignore
-     except Exception as exc:
-@@ -957,15 +969,41 @@ def _build_pyannote_inference(model_or_name: Any) -> Any | None:
-             exc,
-         )
-         return None
--    try:
--        return Inference(model_or_name, window="whole")
--    except Exception as exc:
--        _logger.warning(
--            "speaker_merge: failed to load embedding model %s: %s",
--            model_or_name,
--            exc,
--        )
--        return None
 +
-+    kwargs: dict[str, Any] = {"window": "whole"}
-+    if device and device != "cpu":
-+        try:
-+            import torch  # type: ignore
-+
-+            kwargs["device"] = torch.device(device)
-+        except Exception as exc:  # pragma: no cover - torch always present in prod
-+            _logger.debug(
-+                "speaker_merge: unable to bind embedding model to device %s: %s",
-+                device,
-+                exc,
-+            )
-+
-+    extra_fqns: list[str] = []
-+    last_error: Exception | None = None
-+    for _ in range(_SPEAKER_EMBEDDING_SAFE_GLOBAL_ATTEMPTS):
-+        try:
-+            with diarization_safe_globals_for_torch_load(extra_fqns=extra_fqns):
-+                return Inference(model_or_name, **kwargs)
-+        except Exception as exc:
-+            last_error = exc
-+        retry_fqn = unsupported_global_diarization_fqn_from_error(last_error)
-+        if retry_fqn is None or retry_fqn in extra_fqns:
-+            break
-+        if import_trusted_diarization_symbol(retry_fqn) is None:
-+            break
-+        extra_fqns.append(retry_fqn)
-+
-+    _logger.warning(
-+        "speaker_merge: failed to load embedding model %s: %s",
-+        model_or_name,
-+        last_error,
-+    )
-+    return None
- 
- 
- def _resolve_pyannote_embedding_model(diariser: Diariser) -> EmbeddingModel | None:
-@@ -1011,15 +1049,22 @@ def _resolve_pyannote_embedding_model(diariser: Diariser) -> EmbeddingModel | No
-             model_name: Any = str(raw_embedding_attr)
-         else:
-             model_name = _DEFAULT_SPEAKER_EMBEDDING_MODEL
--        inference = _build_pyannote_inference(model_name)
-+        # ``_lan_effective_device`` is set on the pyannote pipeline model by
-+        # ``load_pyannote_pipeline``. Fall back to ``diariser`` for forward
-+        # compatibility with future code that may copy the attribute up.
-+        effective_device = getattr(
-+            diariser, "_lan_effective_device", None
-+        ) or getattr(pipeline_model, "_lan_effective_device", None)
-+        inference = _build_pyannote_inference(model_name, device=effective_device)
-         if inference is None:
-             setattr(diariser, "_lan_speaker_embedding_unavailable", True)
-             return None
-         resolution_source = "standalone_inference"
- 
-     _logger.info(
--        "speaker_merge: embedding model ready (source=%s)",
-+        "speaker_merge: embedding model ready (source=%s, device=%s)",
-         resolution_source,
-+        getattr(inference, "device", "unknown"),
++    diariser_mode = str(runtime.get("mode") or "unknown").strip().lower() or "unknown"
++    effective_hints = runtime.get("effective_hints")
+     if not isinstance(effective_hints, dict):
+         effective_hints = {}
+-    initial_hints = metadata.get("initial_hints")
++    initial_hints = runtime.get("initial_hints")
+     if not isinstance(initial_hints, dict):
+         initial_hints = {}
+-    profile_selection = metadata.get("profile_selection")
++    profile_selection = runtime.get("profile_selection")
+     if not isinstance(profile_selection, dict):
+         profile_selection = {}
+     selected_profile = str(
+         profile_selection.get("selected_profile")
+-        or metadata.get("selected_profile")
+-        or metadata.get("initial_profile")
+-        or metadata.get("diarization_profile")
++        or runtime.get("selected_profile")
++        or runtime.get("initial_profile")
++        or runtime.get("diarization_profile")
+         or cfg.diarization_profile
      )
+     initial_metrics = profile_selection.get("initial_metrics")
+     if not isinstance(initial_metrics, dict):
+         initial_metrics = {}
  
-     def _embed(audio_path: Path, start: float, end: float):
++    degraded = bool(used_dummy_fallback) or diariser_mode not in {"pyannote", "unknown"}
++
+     payload: dict[str, Any] = {
+         "version": 1,
+         "mode": diariser_mode,
+-        "degraded": _is_degraded_diarization(
+-            diariser,
+-            used_dummy_fallback=used_dummy_fallback,
+-        ),
+-        "diarization_profile": str(metadata.get("diarization_profile") or cfg.diarization_profile),
++        "degraded": degraded,
++        "diarization_profile": str(runtime.get("diarization_profile") or cfg.diarization_profile),
+         "requested_profile": str(
+-            metadata.get("requested_profile")
+-            or metadata.get("diarization_profile")
++            runtime.get("requested_profile")
++            or runtime.get("diarization_profile")
+             or cfg.diarization_profile
+         ),
+-        "effective_device": str(metadata.get("effective_device") or cfg.diarization_device),
+-        "scheduler_mode": str(metadata.get("scheduler_mode") or cfg.gpu_scheduler_mode),
+-        "scheduler_reason": metadata.get("scheduler_reason"),
+-        "initial_profile": str(metadata.get("initial_profile") or cfg.diarization_profile),
++        "effective_device": str(runtime.get("effective_device") or cfg.diarization_device),
++        "scheduler_mode": str(runtime.get("scheduler_mode") or cfg.gpu_scheduler_mode),
++        "scheduler_reason": runtime.get("scheduler_reason"),
++        "initial_profile": str(runtime.get("initial_profile") or cfg.diarization_profile),
+         "selected_profile": selected_profile,
+         "selected_result": str(profile_selection.get("selected_result") or "initial_pass"),
+-        "auto_profile_enabled": bool(metadata.get("auto_profile_enabled", False)),
+-        "profile_override_reason": metadata.get("override_reason"),
++        "auto_profile_enabled": bool(runtime.get("auto_profile_enabled", False)),
++        "profile_override_reason": runtime.get("override_reason"),
+         "hints_applied": effective_hints,
+         "dialog_retry_attempted": bool(
+             profile_selection.get(
+                 "dialog_retry_attempted",
+-                metadata.get("dialog_retry_used", False),
++                runtime.get("dialog_retry_used", False),
+             )
+         ),
+-        "dialog_retry_used": bool(metadata.get("dialog_retry_used", False)),
+-        "speaker_count_before_retry": metadata.get("speaker_count_before_retry"),
+-        "speaker_count_after_retry": metadata.get("speaker_count_after_retry"),
++        "dialog_retry_used": bool(runtime.get("dialog_retry_used", False)),
++        "speaker_count_before_retry": runtime.get("speaker_count_before_retry"),
++        "speaker_count_after_retry": runtime.get("speaker_count_after_retry"),
+         "initial_speaker_count": initial_metrics.get(
+             "speaker_count",
+-            metadata.get("speaker_count_before_retry"),
++            runtime.get("speaker_count_before_retry"),
+         ),
+         "initial_top_two_coverage": initial_metrics.get("top_two_coverage"),
+-        "used_dummy_fallback": used_dummy_fallback,
++        "used_dummy_fallback": bool(used_dummy_fallback),
+         "smoothing_applied": bool(diariser_mode == "pyannote" and not used_dummy_fallback),
+         "merge_gap_seconds": cfg.diarization_merge_gap_seconds,
+         "min_turn_seconds": cfg.diarization_min_turn_seconds,
+@@ -1331,6 +1364,50 @@ def _write_diarization_metadata_artifact(
+         payload["profile_selection"] = profile_selection
+     payload["speaker_merges"] = dict(speaker_merges or {})
+     payload["speaker_merge_diagnostics"] = dict(speaker_merge_diagnostics or {})
++    return payload
++
++
++def _finalize_transcript_payload(
++    base_payload: dict[str, Any],
++    *,
++    speaker_lines: list[str],
++    asr_execution: dict[str, Any],
++    review: dict[str, Any],
++) -> dict[str, Any]:
++    """Attach post-processing fields to a transcript payload.
++
++    Shared builder for ``transcript.json``. Both the legacy monolithic
++    ``run_pipeline`` path and the stage-based ``_stage_export_artifacts``
++    path in ``lan_app.worker_tasks`` call this so that any field added
++    here is automatically preserved by every writer.
++    """
++
++    base_payload["speaker_lines"] = list(speaker_lines)
++    base_payload["multilingual_asr"] = dict(asr_execution or {})
++    base_payload["review"] = dict(review or {})
++    return base_payload
++
++
++def _write_diarization_metadata_artifact(
++    *,
++    artifacts,
++    diariser: Diariser,
++    cfg: Settings,
++    smoothing_result,
++    used_dummy_fallback: bool,
++    speaker_merges: dict[str, str] | None = None,
++    speaker_merge_diagnostics: dict[str, Any] | None = None,
++) -> None:
++    runtime = _diariser_runtime_metadata(diariser)
++    runtime["mode"] = _diariser_mode(diariser)
++    payload = _build_diarization_metadata_payload(
++        runtime=runtime,
++        cfg=cfg,
++        smoothing_result=smoothing_result,
++        used_dummy_fallback=used_dummy_fallback,
++        speaker_merges=speaker_merges,
++        speaker_merge_diagnostics=speaker_merge_diagnostics,
++    )
+     atomic_write_json(artifacts.diarization_metadata_json_path, payload)
+ 
+ 
+@@ -3313,29 +3390,31 @@ async def run_pipeline(
+         serialised_segments = [SpeakerSegment(start=safe_float(turn["start"]), end=safe_float(turn["end"]), speaker=str(turn["speaker"]), text=str(turn["text"])) for turn in speaker_turns]
+         speakers = sorted(set(aliases.get(turn["speaker"], turn["speaker"]) for turn in speaker_turns))
+         atomic_write_text(artifacts.transcript_txt_path, clean_text)
+-        payload = _base_transcript_payload(
+-            recording_id=artifacts.recording_id,
+-            language=language_info,
+-            dominant_language=language_analysis.dominant_language,
+-            language_distribution=language_analysis.distribution,
+-            language_spans=language_analysis.spans,
+-            target_summary_language=summary_lang,
+-            transcript_language_override=override_lang,
+-            calendar_title=cal_title,
+-            calendar_attendees=cal_attendees,
+-            segments=language_analysis.segments,
+-            speakers=speakers,
+-            text=clean_text,
+-        )
+-        payload["speaker_lines"] = speaker_lines
+-        payload["multilingual_asr"] = dict(asr_execution)
+-        payload["review"] = {
+-            "required": bool(language_analysis.review_required),
+-            "reason_code": language_analysis.review_reason_code,
+-            "reason_text": language_analysis.review_reason_text,
+-            "uncertain_segment_count": language_analysis.uncertain_segment_count,
+-            "conflict_segment_count": language_analysis.conflict_segment_count,
+-        }
++        payload = _finalize_transcript_payload(
++            _base_transcript_payload(
++                recording_id=artifacts.recording_id,
++                language=language_info,
++                dominant_language=language_analysis.dominant_language,
++                language_distribution=language_analysis.distribution,
++                language_spans=language_analysis.spans,
++                target_summary_language=summary_lang,
++                transcript_language_override=override_lang,
++                calendar_title=cal_title,
++                calendar_attendees=cal_attendees,
++                segments=language_analysis.segments,
++                speakers=speakers,
++                text=clean_text,
++            ),
++            speaker_lines=speaker_lines,
++            asr_execution=asr_execution,
++            review={
++                "required": bool(language_analysis.review_required),
++                "reason_code": language_analysis.review_reason_code,
++                "reason_text": language_analysis.review_reason_text,
++                "uncertain_segment_count": language_analysis.uncertain_segment_count,
++                "conflict_segment_count": language_analysis.conflict_segment_count,
++            },
++        )
+         atomic_write_json(artifacts.transcript_json_path, payload)
+         atomic_write_json(artifacts.segments_json_path, diar_segments)
+         atomic_write_json(artifacts.speaker_turns_json_path, speaker_turns)
 diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
-index 33bf904..30cd77c 100644
+index e5f1e93..a32c5ce 100644
 --- a/tasks/QUEUE.md
 +++ b/tasks/QUEUE.md
-@@ -711,6 +711,6 @@ Queue (in order)
- - Depends on: PR-SPEAKER-MERGE-DIAGNOSTICS-01
- 
- 142) PR-SPEAKER-MERGE-TORCH-LOAD-FIX-01: Fix speaker merge embedding model: torch.load weights_only failure and CPU-only device
--- Status: TODO
-+- Status: DOING
- - Tasks file: tasks/PR-SPEAKER-MERGE-TORCH-LOAD-FIX-01.md
+@@ -716,7 +716,7 @@ Queue (in order)
  - Depends on: PR-SPEAKER-MERGE-DIAGNOSTICS-HOTFIX-01
-diff --git a/tests/test_speaker_merge.py b/tests/test_speaker_merge.py
-index 824fe62..fb7cdf4 100644
---- a/tests/test_speaker_merge.py
-+++ b/tests/test_speaker_merge.py
-@@ -1057,3 +1057,247 @@ def test_resolve_pyannote_embedding_model_handles_inference_constructor_error()
-         result = pipeline_orchestrator._resolve_pyannote_embedding_model(diariser)
-     assert result is None
-     assert getattr(diariser, "_lan_speaker_embedding_unavailable", False) is True
+ 
+ 143) PR-ARTIFACT-SINGLE-WRITER-01: Eliminate dual artifact writes: make orchestrator the single source of truth for all derived JSON artifacts
+-- Status: TODO
++- Status: DONE
+ - Tasks file: tasks/PR-ARTIFACT-SINGLE-WRITER-01.md
+ - Depends on: PR-SPEAKER-MERGE-TORCH-LOAD-FIX-01
+ 
+diff --git a/tests/test_pipeline_resume_coverage.py b/tests/test_pipeline_resume_coverage.py
+index b9d06ba..9fc8fea 100644
+--- a/tests/test_pipeline_resume_coverage.py
++++ b/tests/test_pipeline_resume_coverage.py
+@@ -29,6 +29,7 @@ from lan_app.db import (
+     set_recording_cancel_request,
+ )
+ from lan_transcriber.pipeline import PrecheckResult
++from lan_transcriber.pipeline_steps import orchestrator as pipeline_orchestrator
+ from lan_transcriber.pipeline_steps.diarization_quality import SpeakerTurnSmoothingResult
+ 
+ 
+@@ -239,6 +240,142 @@ def test_build_diarization_metadata_payload_normalizes_optional_fields(tmp_path:
+     assert "profile_selection" not in payload
+ 
+ 
++def test_worker_diarization_metadata_wrapper_delegates_to_orchestrator(
++    tmp_path: Path,
++) -> None:
++    """Regression guard for PR-ARTIFACT-SINGLE-WRITER-01.
++
++    Ensures ``worker_tasks._build_diarization_metadata_payload`` is only a
++    thin delegate to ``pipeline_orchestrator._build_diarization_metadata_payload``
++    so that any new key added to the orchestrator's shared builder shows up
++    in the stage-based worker path without a parallel code change. This is
++    the exact bug that PR-SPEAKER-MERGE-DIAGNOSTICS-HOTFIX-01 had to fix by
++    hand before consolidation.
++    """
++
++    cfg = worker_tasks._build_pipeline_settings(_cfg(tmp_path))  # noqa: SLF001
++    smoothing_result = SpeakerTurnSmoothingResult(
++        turns=[{"speaker": "S1", "start": 0.0, "end": 1.0, "text": "hello"}],
++        adjacent_merges=0,
++        micro_turn_absorptions=0,
++        turn_count_before=1,
++        turn_count_after=1,
++        speaker_count_before=1,
++        speaker_count_after=1,
++    )
++    runtime = {
++        "mode": "pyannote",
++        "effective_hints": {"min_speakers": 2},
++        "initial_hints": {"min_speakers": 2},
++        "profile_selection": {},
++        "used_dummy_fallback": False,
++    }
++    speaker_merges = {"S2": "S1"}
++    speaker_merge_diagnostics = {
++        "embedding_model_available": True,
++        "speakers_found": ["S1", "S2"],
++        "centroids_computed": ["S1", "S2"],
++        "pairwise_scores": [{"a": "S1", "b": "S2", "score": 0.93}],
++        "merges_applied": {"S2": "S1"},
++        "skipped_reason": None,
++    }
++    worker_payload = worker_tasks._build_diarization_metadata_payload(  # noqa: SLF001
++        runtime=runtime,
++        cfg=cfg,
++        smoothing_result=smoothing_result,
++        speaker_merges=speaker_merges,
++        speaker_merge_diagnostics=speaker_merge_diagnostics,
++    )
++    orchestrator_payload = pipeline_orchestrator._build_diarization_metadata_payload(  # noqa: SLF001
++        runtime=runtime,
++        cfg=cfg,
++        smoothing_result=smoothing_result,
++        used_dummy_fallback=False,
++        speaker_merges=speaker_merges,
++        speaker_merge_diagnostics=speaker_merge_diagnostics,
++    )
++    assert worker_payload == orchestrator_payload
++    assert worker_payload["speaker_merges"] == speaker_merges
++    assert worker_payload["speaker_merge_diagnostics"] == speaker_merge_diagnostics
++    # Field added by orchestrator is preserved end-to-end.
++    assert "speaker_merge_diagnostics" in worker_payload
 +
 +
-+def test_build_pyannote_inference_uses_diarization_safe_globals(
++def test_orchestrator_diarization_metadata_payload_new_field_survives_worker(
++    tmp_path: Path,
 +    monkeypatch: pytest.MonkeyPatch,
 +) -> None:
-+    """The wespeaker checkpoint must be loaded under the trusted safe-globals
-+    context to survive ``torch.load(weights_only=True)``."""
++    """Simulate the PR-140 scenario: a new field added to the orchestrator's
++    shared builder must survive the full worker_tasks write path.
 +
-+    contexts: list[str] = []
++    We monkeypatch the shared orchestrator builder to add an extra key and
++    then call the worker delegate; the key must be present on the returned
++    payload, proving the worker never rebuilds the payload independently.
++    """
 +
-+    class _FakeInference:
-+        def __init__(self, name: str, **kwargs) -> None:
-+            self.name = name
-+            self.kwargs = kwargs
++    cfg = worker_tasks._build_pipeline_settings(_cfg(tmp_path))  # noqa: SLF001
++    smoothing_result = SpeakerTurnSmoothingResult(
++        turns=[],
++        adjacent_merges=0,
++        micro_turn_absorptions=0,
++        turn_count_before=0,
++        turn_count_after=0,
++        speaker_count_before=0,
++        speaker_count_after=0,
++    )
++    original_builder = pipeline_orchestrator._build_diarization_metadata_payload  # noqa: SLF001
 +
-+    fake_audio = types.SimpleNamespace(Inference=_FakeInference)
-+
-+    import contextlib as _contextlib
-+
-+    @_contextlib.contextmanager
-+    def _fake_ctx(extra_fqns=None):
-+        contexts.append("entered")
-+        yield
++    def _augmented_builder(**kwargs):
++        payload = original_builder(**kwargs)
++        payload["pr140_simulated_new_field"] = "present"
++        return payload
 +
 +    monkeypatch.setattr(
 +        pipeline_orchestrator,
-+        "diarization_safe_globals_for_torch_load",
-+        _fake_ctx,
++        "_build_diarization_metadata_payload",
++        _augmented_builder,
 +    )
 +
-+    with _patched_module("pyannote.audio", fake_audio):
-+        inference = pipeline_orchestrator._build_pyannote_inference(
-+            "pyannote/wespeaker-voxceleb-resnet34-LM"
-+        )
-+
-+    assert isinstance(inference, _FakeInference)
-+    assert inference.kwargs == {"window": "whole"}
-+    assert contexts == ["entered"]
-+
-+
-+def test_build_pyannote_inference_passes_torch_device_when_gpu(
-+    monkeypatch: pytest.MonkeyPatch,
-+) -> None:
-+    """When a non-CPU device is provided, it must be forwarded as a
-+    ``torch.device`` object so the embedding model runs on GPU."""
-+
-+    class _FakeInference:
-+        def __init__(self, name: str, **kwargs) -> None:
-+            self.name = name
-+            self.kwargs = kwargs
-+
-+    fake_audio = types.SimpleNamespace(Inference=_FakeInference)
-+
-+    fake_torch = types.SimpleNamespace(device=lambda spec: ("torch.device", spec))
-+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
-+
-+    with _patched_module("pyannote.audio", fake_audio):
-+        inference = pipeline_orchestrator._build_pyannote_inference(
-+            "pyannote/wespeaker-voxceleb-resnet34-LM",
-+            device="cuda:0",
-+        )
-+
-+    assert isinstance(inference, _FakeInference)
-+    assert inference.kwargs.get("window") == "whole"
-+    assert inference.kwargs.get("device") == ("torch.device", "cuda:0")
-+
-+
-+def test_build_pyannote_inference_skips_device_for_cpu(
-+    monkeypatch: pytest.MonkeyPatch,
-+) -> None:
-+    """``device='cpu'`` should not pass a torch.device kwarg (matches
-+    pre-existing CPU-only behaviour)."""
-+
-+    class _FakeInference:
-+        def __init__(self, name: str, **kwargs) -> None:
-+            self.name = name
-+            self.kwargs = kwargs
-+
-+    fake_audio = types.SimpleNamespace(Inference=_FakeInference)
-+
-+    with _patched_module("pyannote.audio", fake_audio):
-+        inference = pipeline_orchestrator._build_pyannote_inference(
-+            "pyannote/wespeaker-voxceleb-resnet34-LM",
-+            device="cpu",
-+        )
-+    assert isinstance(inference, _FakeInference)
-+    assert "device" not in inference.kwargs
-+
-+
-+def test_build_pyannote_inference_retries_on_unsupported_global(
-+    monkeypatch: pytest.MonkeyPatch,
-+) -> None:
-+    """If the first load attempt raises ``Unsupported global``, the helper
-+    must extract the FQN, allowlist it, and retry — mirroring the diarization
-+    pipeline loader's safe-globals retry."""
-+
-+    attempts: list[list[str]] = []
-+
-+    class _FakeInference:
-+        def __init__(self, name: str, **kwargs) -> None:
-+            extras = list(_current_extras["value"])
-+            attempts.append(extras)
-+            if not extras:
-+                raise RuntimeError(
-+                    "Unsupported global: GLOBAL omegaconf.base.ContainerMetadata"
-+                )
-+            self.name = name
-+            self.kwargs = kwargs
-+
-+    fake_audio = types.SimpleNamespace(Inference=_FakeInference)
-+
-+    _current_extras: dict[str, list[str]] = {"value": []}
-+
-+    import contextlib as _contextlib
-+
-+    @_contextlib.contextmanager
-+    def _fake_ctx(extra_fqns=None):
-+        _current_extras["value"] = list(extra_fqns or [])
-+        yield
-+
-+    monkeypatch.setattr(
-+        pipeline_orchestrator,
-+        "diarization_safe_globals_for_torch_load",
-+        _fake_ctx,
++    payload = worker_tasks._build_diarization_metadata_payload(  # noqa: SLF001
++        runtime={"mode": "pyannote"},
++        cfg=cfg,
++        smoothing_result=smoothing_result,
 +    )
-+    monkeypatch.setattr(
-+        pipeline_orchestrator,
-+        "import_trusted_diarization_symbol",
-+        lambda fqn: object(),
++    assert payload["pr140_simulated_new_field"] == "present"
++
++
++def test_finalize_transcript_payload_merges_speaker_lines_and_review() -> None:
++    base = {
++        "recording_id": "rec-1",
++        "segments": [],
++        "speakers": ["S1"],
++        "text": "hello",
++    }
++    finalized = pipeline_orchestrator._finalize_transcript_payload(  # noqa: SLF001
++        base,
++        speaker_lines=["[0.00-1.00] **S1:** hello"],
++        asr_execution={"used_multilingual_path": False, "selected_mode": "mono"},
++        review={"required": True, "reason_code": "low_confidence"},
 +    )
-+
-+    with _patched_module("pyannote.audio", fake_audio):
-+        inference = pipeline_orchestrator._build_pyannote_inference(
-+            "pyannote/wespeaker-voxceleb-resnet34-LM"
-+        )
-+
-+    assert isinstance(inference, _FakeInference)
-+    assert attempts[0] == []
-+    assert "omegaconf.base.ContainerMetadata" in attempts[1]
-+
-+
-+def test_build_pyannote_inference_breaks_when_retry_fqn_untrusted(
-+    monkeypatch: pytest.MonkeyPatch,
-+) -> None:
-+    """If the unsupported-global FQN cannot be imported via the trusted
-+    diarization allowlist, the helper must stop retrying and return None."""
-+
-+    class _FakeInference:
-+        def __init__(self, *_args, **_kwargs) -> None:
-+            raise RuntimeError(
-+                "Unsupported global: GLOBAL omegaconf.base.ContainerMetadata"
-+            )
-+
-+    fake_audio = types.SimpleNamespace(Inference=_FakeInference)
-+
-+    monkeypatch.setattr(
-+        pipeline_orchestrator,
-+        "import_trusted_diarization_symbol",
-+        lambda fqn: None,
++    assert finalized is base  # finalization mutates in place and returns the same dict
++    assert finalized["speaker_lines"] == ["[0.00-1.00] **S1:** hello"]
++    assert finalized["multilingual_asr"] == {
++        "used_multilingual_path": False,
++        "selected_mode": "mono",
++    }
++    assert finalized["review"] == {"required": True, "reason_code": "low_confidence"}
++    # Empty/None asr execution and review collapse to empty dicts.
++    finalized = pipeline_orchestrator._finalize_transcript_payload(  # noqa: SLF001
++        {"recording_id": "rec-2"},
++        speaker_lines=[],
++        asr_execution=None,  # type: ignore[arg-type]
++        review=None,  # type: ignore[arg-type]
 +    )
-+
-+    with _patched_module("pyannote.audio", fake_audio):
-+        result = pipeline_orchestrator._build_pyannote_inference(
-+            "pyannote/wespeaker-voxceleb-resnet34-LM"
-+        )
-+    assert result is None
++    assert finalized["speaker_lines"] == []
++    assert finalized["multilingual_asr"] == {}
++    assert finalized["review"] == {}
 +
 +
-+def test_build_pyannote_inference_exhausts_retry_budget(
-+    monkeypatch: pytest.MonkeyPatch,
-+) -> None:
-+    """When every attempt raises with a fresh retryable FQN, the helper must
-+    bound retries via the safe-global attempt budget and eventually return
-+    None instead of looping forever."""
-+
-+    suffixes = ["A", "B", "C", "D", "E"]
-+    counter = {"i": 0}
-+
-+    class _FakeInference:
-+        def __init__(self, *_args, **_kwargs) -> None:
-+            i = counter["i"]
-+            counter["i"] += 1
-+            sym = suffixes[i]
-+            raise RuntimeError(f"Unsupported global: GLOBAL omegaconf.test.{sym}")
-+
-+    fake_audio = types.SimpleNamespace(Inference=_FakeInference)
-+
-+    monkeypatch.setattr(
-+        pipeline_orchestrator,
-+        "import_trusted_diarization_symbol",
-+        lambda fqn: object(),
-+    )
-+
-+    with _patched_module("pyannote.audio", fake_audio):
-+        result = pipeline_orchestrator._build_pyannote_inference(
-+            "pyannote/wespeaker-voxceleb-resnet34-LM"
-+        )
-+    assert result is None
-+    # The helper must respect the retry budget (3) and not loop indefinitely.
-+    assert counter["i"] == 3
-+
-+
-+def test_resolve_pyannote_embedding_model_forwards_pipeline_device() -> None:
-+    """The embedding model should run on the same device as the diarization
-+    pipeline (set via ``_lan_effective_device`` on the pipeline_model)."""
-+
-+    pipeline_model = types.SimpleNamespace(
-+        embedding="pyannote/wespeaker-voxceleb-resnet34-LM",
-+        _lan_effective_device="cuda:0",
-+    )
-+    diariser = _StubDiariser(
-+        pipeline_model=pipeline_model, pipeline_attr="_pipeline_model"
-+    )
-+
-+    constructed: list["_FakeInference"] = []
-+
-+    class _FakeInference:
-+        def __init__(self, name: str, **kwargs) -> None:
-+            self.name = name
-+            self.kwargs = kwargs
-+            self.device = kwargs.get("device")
-+            constructed.append(self)
-+
-+        def crop(self, path: str, segment):
-+            return [0.1, 0.9]
-+
-+    fake_audio = types.SimpleNamespace(Inference=_FakeInference)
-+    fake_torch = types.SimpleNamespace(device=lambda spec: ("torch.device", spec))
-+
-+    saved = sys.modules.get("torch")
-+    sys.modules["torch"] = fake_torch  # type: ignore[assignment]
-+    try:
-+        with _patched_module("pyannote.audio", fake_audio):
-+            model_callable = pipeline_orchestrator._resolve_pyannote_embedding_model(
-+                diariser
-+            )
-+    finally:
-+        if saved is None:
-+            sys.modules.pop("torch", None)
-+        else:
-+            sys.modules["torch"] = saved
-+    assert callable(model_callable)
-+    assert len(constructed) == 1
-+    assert constructed[0].kwargs.get("device") == ("torch.device", "cuda:0")
+ def test_stage_precheck_with_missing_duration_and_calendar_refresh_warning(
+     tmp_path: Path,
+     monkeypatch: pytest.MonkeyPatch,

--- a/lan_app/worker_tasks.py
+++ b/lan_app/worker_tasks.py
@@ -2574,77 +2574,23 @@ def _build_diarization_metadata_payload(
     speaker_merges: dict[str, str] | None = None,
     speaker_merge_diagnostics: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    diariser_mode = str(runtime.get("mode") or "unknown").strip().lower() or "unknown"
-    effective_hints = runtime.get("effective_hints")
-    if not isinstance(effective_hints, dict):
-        effective_hints = {}
-    initial_hints = runtime.get("initial_hints")
-    if not isinstance(initial_hints, dict):
-        initial_hints = {}
-    profile_selection = runtime.get("profile_selection")
-    if not isinstance(profile_selection, dict):
-        profile_selection = {}
-    selected_profile = str(
-        profile_selection.get("selected_profile")
-        or runtime.get("selected_profile")
-        or runtime.get("initial_profile")
-        or runtime.get("diarization_profile")
-        or cfg.diarization_profile
+    """Thin wrapper that delegates to the orchestrator's shared builder.
+
+    PR-ARTIFACT-SINGLE-WRITER-01 consolidated the diarization metadata
+    payload construction into a single source of truth in
+    ``lan_transcriber.pipeline_steps.orchestrator``. The wrapper is kept
+    so existing tests that reference ``worker_tasks._build_diarization_metadata_payload``
+    continue to hit the same code path the production pipeline uses.
+    """
+
+    return pipeline_orchestrator._build_diarization_metadata_payload(  # noqa: SLF001
+        runtime=runtime,
+        cfg=cfg,
+        smoothing_result=smoothing_result,
+        used_dummy_fallback=bool(runtime.get("used_dummy_fallback", False)),
+        speaker_merges=speaker_merges,
+        speaker_merge_diagnostics=speaker_merge_diagnostics,
     )
-    initial_metrics = profile_selection.get("initial_metrics")
-    if not isinstance(initial_metrics, dict):
-        initial_metrics = {}
-    payload: dict[str, Any] = {
-        "version": 1,
-        "mode": diariser_mode,
-        "degraded": bool(runtime.get("used_dummy_fallback")) or diariser_mode not in {"pyannote", "unknown"},
-        "diarization_profile": str(runtime.get("diarization_profile") or cfg.diarization_profile),
-        "requested_profile": str(
-            runtime.get("requested_profile")
-            or runtime.get("diarization_profile")
-            or cfg.diarization_profile
-        ),
-        "effective_device": str(runtime.get("effective_device") or cfg.diarization_device),
-        "scheduler_mode": str(runtime.get("scheduler_mode") or cfg.gpu_scheduler_mode),
-        "scheduler_reason": runtime.get("scheduler_reason"),
-        "initial_profile": str(runtime.get("initial_profile") or cfg.diarization_profile),
-        "selected_profile": selected_profile,
-        "selected_result": str(profile_selection.get("selected_result") or "initial_pass"),
-        "auto_profile_enabled": bool(runtime.get("auto_profile_enabled", False)),
-        "profile_override_reason": runtime.get("override_reason"),
-        "hints_applied": effective_hints,
-        "dialog_retry_attempted": bool(
-            profile_selection.get(
-                "dialog_retry_attempted",
-                runtime.get("dialog_retry_used", False),
-            )
-        ),
-        "dialog_retry_used": bool(runtime.get("dialog_retry_used", False)),
-        "speaker_count_before_retry": runtime.get("speaker_count_before_retry"),
-        "speaker_count_after_retry": runtime.get("speaker_count_after_retry"),
-        "initial_speaker_count": initial_metrics.get(
-            "speaker_count",
-            runtime.get("speaker_count_before_retry"),
-        ),
-        "initial_top_two_coverage": initial_metrics.get("top_two_coverage"),
-        "used_dummy_fallback": bool(runtime.get("used_dummy_fallback", False)),
-        "smoothing_applied": bool(diariser_mode == "pyannote" and not runtime.get("used_dummy_fallback")),
-        "merge_gap_seconds": cfg.diarization_merge_gap_seconds,
-        "min_turn_seconds": cfg.diarization_min_turn_seconds,
-        "speaker_count_before_smoothing": smoothing_result.speaker_count_before,
-        "speaker_count_after_smoothing": smoothing_result.speaker_count_after,
-        "turn_count_before_smoothing": smoothing_result.turn_count_before,
-        "turn_count_after_smoothing": smoothing_result.turn_count_after,
-        "adjacent_merges": smoothing_result.adjacent_merges,
-        "micro_turn_absorptions": smoothing_result.micro_turn_absorptions,
-    }
-    if initial_hints != effective_hints:
-        payload["initial_hints"] = initial_hints
-    if profile_selection:
-        payload["profile_selection"] = profile_selection
-    payload["speaker_merges"] = dict(speaker_merges or {})
-    payload["speaker_merge_diagnostics"] = dict(speaker_merge_diagnostics or {})
-    return payload
 
 
 def _stage_sanitize_audio(ctx: _PipelineExecutionContext) -> _StageResult:
@@ -3570,28 +3516,30 @@ def _stage_export_artifacts(ctx: _PipelineExecutionContext) -> _StageResult:
         ],
         ctx.pipeline_settings.merge_similar,
     )
-    transcript_payload = pipeline_orchestrator._base_transcript_payload(
-        recording_id=ctx.recording_id,
-        language=language_info,
-        dominant_language=str(ctx.language_payload.get("dominant_language") or "unknown"),
-        language_distribution=dict(ctx.language_payload.get("language_distribution") or {}),
-        language_spans=list(ctx.language_payload.get("language_spans") or []),
-        target_summary_language=summary_lang,
-        transcript_language_override=ctx.transcript_language_override,
-        calendar_title=ctx.calendar_title,
-        calendar_attendees=ctx.calendar_attendees,
-        segments=language_segments,
-        speakers=sorted(
-            {
-                aliases.get(str(turn.get("speaker") or "S1"), str(turn.get("speaker") or "S1"))
-                for turn in ctx.speaker_turns
-            }
+    transcript_payload = pipeline_orchestrator._finalize_transcript_payload(
+        pipeline_orchestrator._base_transcript_payload(
+            recording_id=ctx.recording_id,
+            language=language_info,
+            dominant_language=str(ctx.language_payload.get("dominant_language") or "unknown"),
+            language_distribution=dict(ctx.language_payload.get("language_distribution") or {}),
+            language_spans=list(ctx.language_payload.get("language_spans") or []),
+            target_summary_language=summary_lang,
+            transcript_language_override=ctx.transcript_language_override,
+            calendar_title=ctx.calendar_title,
+            calendar_attendees=ctx.calendar_attendees,
+            segments=language_segments,
+            speakers=sorted(
+                {
+                    aliases.get(str(turn.get("speaker") or "S1"), str(turn.get("speaker") or "S1"))
+                    for turn in ctx.speaker_turns
+                }
+            ),
+            text=ctx.clean_text,
         ),
-        text=ctx.clean_text,
+        speaker_lines=speaker_lines,
+        asr_execution=ctx.asr_execution,
+        review=ctx.language_payload.get("review") or {},
     )
-    transcript_payload["speaker_lines"] = speaker_lines
-    transcript_payload["multilingual_asr"] = dict(ctx.asr_execution)
-    transcript_payload["review"] = dict(ctx.language_payload.get("review") or {})
     atomic_write_text(ctx.artifacts.recording_artifacts.transcript_txt_path, ctx.clean_text)
     atomic_write_json(ctx.artifacts.recording_artifacts.transcript_json_path, transcript_payload)
     atomic_write_json(ctx.artifacts.recording_artifacts.segments_json_path, ctx.diarization_segments)

--- a/lan_transcriber/pipeline_steps/orchestrator.py
+++ b/lan_transcriber/pipeline_steps/orchestrator.py
@@ -1246,75 +1246,108 @@ async def _maybe_retry_dialog_diarization(
     return retry_result if winner_is_retry else diarization
 
 
-def _write_diarization_metadata_artifact(
+# -----------------------------------------------------------------------------
+# Shared artifact payload builders (PR-ARTIFACT-SINGLE-WRITER-01)
+#
+# These helpers exist so that the legacy monolithic ``run_pipeline`` path and
+# the stage-based execution in ``lan_app.worker_tasks`` build derived JSON
+# artifact payloads from a single source. Before PR-ARTIFACT-SINGLE-WRITER-01,
+# ``lan_app.worker_tasks`` had its own parallel implementations that silently
+# dropped fields when orchestrator payloads gained new keys (see
+# PR-SPEAKER-MERGE-DIAGNOSTICS-HOTFIX-01). Always extend these shared builders
+# when adding fields, and call them from both the orchestrator and the worker.
+#
+# Conflict matrix of derived artifacts that can be written by both paths:
+#   diarization_metadata.json : stage path writes in ``_stage_speaker_turns``;
+#                               legacy path writes in ``_write_diarization_metadata_artifact``.
+#                               Shared builder: ``_build_diarization_metadata_payload``.
+#   transcript.json           : stage path writes in ``_stage_export_artifacts``;
+#                               legacy path writes at the end of ``run_pipeline``.
+#                               Shared builder: ``_finalize_transcript_payload``.
+#   segments.json             : list payload copied verbatim from ``diar_segments``.
+#   speaker_turns.json        : list payload copied verbatim from smoothed turns.
+#   summary.json              : dict payload produced by ``build_summary_payload`` or
+#                               ``_build_structured_summary_payload`` (already shared).
+#   transcript.txt            : plain text copy of ``clean_text``.
+#   metrics.json              : independent per-path (legacy: run_pipeline; stage:
+#                               ``_stage_metrics``). Not a dual-write conflict.
+# -----------------------------------------------------------------------------
+
+
+def _build_diarization_metadata_payload(
     *,
-    artifacts,
-    diariser: Diariser,
+    runtime: dict[str, Any],
     cfg: Settings,
     smoothing_result,
     used_dummy_fallback: bool,
     speaker_merges: dict[str, str] | None = None,
     speaker_merge_diagnostics: dict[str, Any] | None = None,
-) -> None:
-    metadata = _diariser_runtime_metadata(diariser)
-    diariser_mode = _diariser_mode(diariser)
-    effective_hints = metadata.get("effective_hints")
+) -> dict[str, Any]:
+    """Build the ``diarization_metadata.json`` payload from a runtime dict.
+
+    This is the single source of truth for diarization metadata fields.
+    Both ``_write_diarization_metadata_artifact`` (legacy monolithic path)
+    and ``lan_app.worker_tasks._stage_speaker_turns`` (stage-based production
+    path) call this function so that payload fields stay in sync.
+    """
+
+    diariser_mode = str(runtime.get("mode") or "unknown").strip().lower() or "unknown"
+    effective_hints = runtime.get("effective_hints")
     if not isinstance(effective_hints, dict):
         effective_hints = {}
-    initial_hints = metadata.get("initial_hints")
+    initial_hints = runtime.get("initial_hints")
     if not isinstance(initial_hints, dict):
         initial_hints = {}
-    profile_selection = metadata.get("profile_selection")
+    profile_selection = runtime.get("profile_selection")
     if not isinstance(profile_selection, dict):
         profile_selection = {}
     selected_profile = str(
         profile_selection.get("selected_profile")
-        or metadata.get("selected_profile")
-        or metadata.get("initial_profile")
-        or metadata.get("diarization_profile")
+        or runtime.get("selected_profile")
+        or runtime.get("initial_profile")
+        or runtime.get("diarization_profile")
         or cfg.diarization_profile
     )
     initial_metrics = profile_selection.get("initial_metrics")
     if not isinstance(initial_metrics, dict):
         initial_metrics = {}
 
+    degraded = bool(used_dummy_fallback) or diariser_mode not in {"pyannote", "unknown"}
+
     payload: dict[str, Any] = {
         "version": 1,
         "mode": diariser_mode,
-        "degraded": _is_degraded_diarization(
-            diariser,
-            used_dummy_fallback=used_dummy_fallback,
-        ),
-        "diarization_profile": str(metadata.get("diarization_profile") or cfg.diarization_profile),
+        "degraded": degraded,
+        "diarization_profile": str(runtime.get("diarization_profile") or cfg.diarization_profile),
         "requested_profile": str(
-            metadata.get("requested_profile")
-            or metadata.get("diarization_profile")
+            runtime.get("requested_profile")
+            or runtime.get("diarization_profile")
             or cfg.diarization_profile
         ),
-        "effective_device": str(metadata.get("effective_device") or cfg.diarization_device),
-        "scheduler_mode": str(metadata.get("scheduler_mode") or cfg.gpu_scheduler_mode),
-        "scheduler_reason": metadata.get("scheduler_reason"),
-        "initial_profile": str(metadata.get("initial_profile") or cfg.diarization_profile),
+        "effective_device": str(runtime.get("effective_device") or cfg.diarization_device),
+        "scheduler_mode": str(runtime.get("scheduler_mode") or cfg.gpu_scheduler_mode),
+        "scheduler_reason": runtime.get("scheduler_reason"),
+        "initial_profile": str(runtime.get("initial_profile") or cfg.diarization_profile),
         "selected_profile": selected_profile,
         "selected_result": str(profile_selection.get("selected_result") or "initial_pass"),
-        "auto_profile_enabled": bool(metadata.get("auto_profile_enabled", False)),
-        "profile_override_reason": metadata.get("override_reason"),
+        "auto_profile_enabled": bool(runtime.get("auto_profile_enabled", False)),
+        "profile_override_reason": runtime.get("override_reason"),
         "hints_applied": effective_hints,
         "dialog_retry_attempted": bool(
             profile_selection.get(
                 "dialog_retry_attempted",
-                metadata.get("dialog_retry_used", False),
+                runtime.get("dialog_retry_used", False),
             )
         ),
-        "dialog_retry_used": bool(metadata.get("dialog_retry_used", False)),
-        "speaker_count_before_retry": metadata.get("speaker_count_before_retry"),
-        "speaker_count_after_retry": metadata.get("speaker_count_after_retry"),
+        "dialog_retry_used": bool(runtime.get("dialog_retry_used", False)),
+        "speaker_count_before_retry": runtime.get("speaker_count_before_retry"),
+        "speaker_count_after_retry": runtime.get("speaker_count_after_retry"),
         "initial_speaker_count": initial_metrics.get(
             "speaker_count",
-            metadata.get("speaker_count_before_retry"),
+            runtime.get("speaker_count_before_retry"),
         ),
         "initial_top_two_coverage": initial_metrics.get("top_two_coverage"),
-        "used_dummy_fallback": used_dummy_fallback,
+        "used_dummy_fallback": bool(used_dummy_fallback),
         "smoothing_applied": bool(diariser_mode == "pyannote" and not used_dummy_fallback),
         "merge_gap_seconds": cfg.diarization_merge_gap_seconds,
         "min_turn_seconds": cfg.diarization_min_turn_seconds,
@@ -1331,6 +1364,50 @@ def _write_diarization_metadata_artifact(
         payload["profile_selection"] = profile_selection
     payload["speaker_merges"] = dict(speaker_merges or {})
     payload["speaker_merge_diagnostics"] = dict(speaker_merge_diagnostics or {})
+    return payload
+
+
+def _finalize_transcript_payload(
+    base_payload: dict[str, Any],
+    *,
+    speaker_lines: list[str],
+    asr_execution: dict[str, Any],
+    review: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach post-processing fields to a transcript payload.
+
+    Shared builder for ``transcript.json``. Both the legacy monolithic
+    ``run_pipeline`` path and the stage-based ``_stage_export_artifacts``
+    path in ``lan_app.worker_tasks`` call this so that any field added
+    here is automatically preserved by every writer.
+    """
+
+    base_payload["speaker_lines"] = list(speaker_lines)
+    base_payload["multilingual_asr"] = dict(asr_execution or {})
+    base_payload["review"] = dict(review or {})
+    return base_payload
+
+
+def _write_diarization_metadata_artifact(
+    *,
+    artifacts,
+    diariser: Diariser,
+    cfg: Settings,
+    smoothing_result,
+    used_dummy_fallback: bool,
+    speaker_merges: dict[str, str] | None = None,
+    speaker_merge_diagnostics: dict[str, Any] | None = None,
+) -> None:
+    runtime = _diariser_runtime_metadata(diariser)
+    runtime["mode"] = _diariser_mode(diariser)
+    payload = _build_diarization_metadata_payload(
+        runtime=runtime,
+        cfg=cfg,
+        smoothing_result=smoothing_result,
+        used_dummy_fallback=used_dummy_fallback,
+        speaker_merges=speaker_merges,
+        speaker_merge_diagnostics=speaker_merge_diagnostics,
+    )
     atomic_write_json(artifacts.diarization_metadata_json_path, payload)
 
 
@@ -3313,29 +3390,31 @@ async def run_pipeline(
         serialised_segments = [SpeakerSegment(start=safe_float(turn["start"]), end=safe_float(turn["end"]), speaker=str(turn["speaker"]), text=str(turn["text"])) for turn in speaker_turns]
         speakers = sorted(set(aliases.get(turn["speaker"], turn["speaker"]) for turn in speaker_turns))
         atomic_write_text(artifacts.transcript_txt_path, clean_text)
-        payload = _base_transcript_payload(
-            recording_id=artifacts.recording_id,
-            language=language_info,
-            dominant_language=language_analysis.dominant_language,
-            language_distribution=language_analysis.distribution,
-            language_spans=language_analysis.spans,
-            target_summary_language=summary_lang,
-            transcript_language_override=override_lang,
-            calendar_title=cal_title,
-            calendar_attendees=cal_attendees,
-            segments=language_analysis.segments,
-            speakers=speakers,
-            text=clean_text,
+        payload = _finalize_transcript_payload(
+            _base_transcript_payload(
+                recording_id=artifacts.recording_id,
+                language=language_info,
+                dominant_language=language_analysis.dominant_language,
+                language_distribution=language_analysis.distribution,
+                language_spans=language_analysis.spans,
+                target_summary_language=summary_lang,
+                transcript_language_override=override_lang,
+                calendar_title=cal_title,
+                calendar_attendees=cal_attendees,
+                segments=language_analysis.segments,
+                speakers=speakers,
+                text=clean_text,
+            ),
+            speaker_lines=speaker_lines,
+            asr_execution=asr_execution,
+            review={
+                "required": bool(language_analysis.review_required),
+                "reason_code": language_analysis.review_reason_code,
+                "reason_text": language_analysis.review_reason_text,
+                "uncertain_segment_count": language_analysis.uncertain_segment_count,
+                "conflict_segment_count": language_analysis.conflict_segment_count,
+            },
         )
-        payload["speaker_lines"] = speaker_lines
-        payload["multilingual_asr"] = dict(asr_execution)
-        payload["review"] = {
-            "required": bool(language_analysis.review_required),
-            "reason_code": language_analysis.review_reason_code,
-            "reason_text": language_analysis.review_reason_text,
-            "uncertain_segment_count": language_analysis.uncertain_segment_count,
-            "conflict_segment_count": language_analysis.conflict_segment_count,
-        }
         atomic_write_json(artifacts.transcript_json_path, payload)
         atomic_write_json(artifacts.segments_json_path, diar_segments)
         atomic_write_json(artifacts.speaker_turns_json_path, speaker_turns)

--- a/tasks/QUEUE.md
+++ b/tasks/QUEUE.md
@@ -716,7 +716,7 @@ Queue (in order)
 - Depends on: PR-SPEAKER-MERGE-DIAGNOSTICS-HOTFIX-01
 
 143) PR-ARTIFACT-SINGLE-WRITER-01: Eliminate dual artifact writes: make orchestrator the single source of truth for all derived JSON artifacts
-- Status: TODO
+- Status: DONE
 - Tasks file: tasks/PR-ARTIFACT-SINGLE-WRITER-01.md
 - Depends on: PR-SPEAKER-MERGE-TORCH-LOAD-FIX-01
 

--- a/tests/test_pipeline_resume_coverage.py
+++ b/tests/test_pipeline_resume_coverage.py
@@ -29,6 +29,7 @@ from lan_app.db import (
     set_recording_cancel_request,
 )
 from lan_transcriber.pipeline import PrecheckResult
+from lan_transcriber.pipeline_steps import orchestrator as pipeline_orchestrator
 from lan_transcriber.pipeline_steps.diarization_quality import SpeakerTurnSmoothingResult
 
 
@@ -237,6 +238,142 @@ def test_build_diarization_metadata_payload_normalizes_optional_fields(tmp_path:
     )
     assert payload["initial_hints"] == {"min_speakers": 1}
     assert "profile_selection" not in payload
+
+
+def test_worker_diarization_metadata_wrapper_delegates_to_orchestrator(
+    tmp_path: Path,
+) -> None:
+    """Regression guard for PR-ARTIFACT-SINGLE-WRITER-01.
+
+    Ensures ``worker_tasks._build_diarization_metadata_payload`` is only a
+    thin delegate to ``pipeline_orchestrator._build_diarization_metadata_payload``
+    so that any new key added to the orchestrator's shared builder shows up
+    in the stage-based worker path without a parallel code change. This is
+    the exact bug that PR-SPEAKER-MERGE-DIAGNOSTICS-HOTFIX-01 had to fix by
+    hand before consolidation.
+    """
+
+    cfg = worker_tasks._build_pipeline_settings(_cfg(tmp_path))  # noqa: SLF001
+    smoothing_result = SpeakerTurnSmoothingResult(
+        turns=[{"speaker": "S1", "start": 0.0, "end": 1.0, "text": "hello"}],
+        adjacent_merges=0,
+        micro_turn_absorptions=0,
+        turn_count_before=1,
+        turn_count_after=1,
+        speaker_count_before=1,
+        speaker_count_after=1,
+    )
+    runtime = {
+        "mode": "pyannote",
+        "effective_hints": {"min_speakers": 2},
+        "initial_hints": {"min_speakers": 2},
+        "profile_selection": {},
+        "used_dummy_fallback": False,
+    }
+    speaker_merges = {"S2": "S1"}
+    speaker_merge_diagnostics = {
+        "embedding_model_available": True,
+        "speakers_found": ["S1", "S2"],
+        "centroids_computed": ["S1", "S2"],
+        "pairwise_scores": [{"a": "S1", "b": "S2", "score": 0.93}],
+        "merges_applied": {"S2": "S1"},
+        "skipped_reason": None,
+    }
+    worker_payload = worker_tasks._build_diarization_metadata_payload(  # noqa: SLF001
+        runtime=runtime,
+        cfg=cfg,
+        smoothing_result=smoothing_result,
+        speaker_merges=speaker_merges,
+        speaker_merge_diagnostics=speaker_merge_diagnostics,
+    )
+    orchestrator_payload = pipeline_orchestrator._build_diarization_metadata_payload(  # noqa: SLF001
+        runtime=runtime,
+        cfg=cfg,
+        smoothing_result=smoothing_result,
+        used_dummy_fallback=False,
+        speaker_merges=speaker_merges,
+        speaker_merge_diagnostics=speaker_merge_diagnostics,
+    )
+    assert worker_payload == orchestrator_payload
+    assert worker_payload["speaker_merges"] == speaker_merges
+    assert worker_payload["speaker_merge_diagnostics"] == speaker_merge_diagnostics
+    # Field added by orchestrator is preserved end-to-end.
+    assert "speaker_merge_diagnostics" in worker_payload
+
+
+def test_orchestrator_diarization_metadata_payload_new_field_survives_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulate the PR-140 scenario: a new field added to the orchestrator's
+    shared builder must survive the full worker_tasks write path.
+
+    We monkeypatch the shared orchestrator builder to add an extra key and
+    then call the worker delegate; the key must be present on the returned
+    payload, proving the worker never rebuilds the payload independently.
+    """
+
+    cfg = worker_tasks._build_pipeline_settings(_cfg(tmp_path))  # noqa: SLF001
+    smoothing_result = SpeakerTurnSmoothingResult(
+        turns=[],
+        adjacent_merges=0,
+        micro_turn_absorptions=0,
+        turn_count_before=0,
+        turn_count_after=0,
+        speaker_count_before=0,
+        speaker_count_after=0,
+    )
+    original_builder = pipeline_orchestrator._build_diarization_metadata_payload  # noqa: SLF001
+
+    def _augmented_builder(**kwargs):
+        payload = original_builder(**kwargs)
+        payload["pr140_simulated_new_field"] = "present"
+        return payload
+
+    monkeypatch.setattr(
+        pipeline_orchestrator,
+        "_build_diarization_metadata_payload",
+        _augmented_builder,
+    )
+
+    payload = worker_tasks._build_diarization_metadata_payload(  # noqa: SLF001
+        runtime={"mode": "pyannote"},
+        cfg=cfg,
+        smoothing_result=smoothing_result,
+    )
+    assert payload["pr140_simulated_new_field"] == "present"
+
+
+def test_finalize_transcript_payload_merges_speaker_lines_and_review() -> None:
+    base = {
+        "recording_id": "rec-1",
+        "segments": [],
+        "speakers": ["S1"],
+        "text": "hello",
+    }
+    finalized = pipeline_orchestrator._finalize_transcript_payload(  # noqa: SLF001
+        base,
+        speaker_lines=["[0.00-1.00] **S1:** hello"],
+        asr_execution={"used_multilingual_path": False, "selected_mode": "mono"},
+        review={"required": True, "reason_code": "low_confidence"},
+    )
+    assert finalized is base  # finalization mutates in place and returns the same dict
+    assert finalized["speaker_lines"] == ["[0.00-1.00] **S1:** hello"]
+    assert finalized["multilingual_asr"] == {
+        "used_multilingual_path": False,
+        "selected_mode": "mono",
+    }
+    assert finalized["review"] == {"required": True, "reason_code": "low_confidence"}
+    # Empty/None asr execution and review collapse to empty dicts.
+    finalized = pipeline_orchestrator._finalize_transcript_payload(  # noqa: SLF001
+        {"recording_id": "rec-2"},
+        speaker_lines=[],
+        asr_execution=None,  # type: ignore[arg-type]
+        review=None,  # type: ignore[arg-type]
+    )
+    assert finalized["speaker_lines"] == []
+    assert finalized["multilingual_asr"] == {}
+    assert finalized["review"] == {}
 
 
 def test_stage_precheck_with_missing_duration_and_calendar_refresh_warning(


### PR DESCRIPTION
## Summary
- Promote diarization_metadata payload construction into a single shared builder in `lan_transcriber.pipeline_steps.orchestrator` so the legacy `run_pipeline` path and the stage-based `lan_app.worker_tasks` path can't silently drift (root cause of PR-SPEAKER-MERGE-DIAGNOSTICS-HOTFIX-01).
- Promote transcript-payload finalization (`speaker_lines` / `multilingual_asr` / `review`) into `_finalize_transcript_payload` and call it from both writers.
- Document the dual-write conflict matrix in an orchestrator-level comment and add regression tests guarding the worker delegate.

## PR metadata
- PR_ID: PR-ARTIFACT-SINGLE-WRITER-01
- TASK_FILE: tasks/PR-ARTIFACT-SINGLE-WRITER-01.md
- Branch: pr-artifact-single-writer-01

## What changed
- `lan_transcriber/pipeline_steps/orchestrator.py`: new shared `_build_diarization_metadata_payload(runtime, …)` and `_finalize_transcript_payload(base, …)`; `_write_diarization_metadata_artifact` and `run_pipeline`'s transcript write now delegate to them. Added a conflict matrix comment above the shared builders.
- `lan_app/worker_tasks.py`: removed the 80-line duplicate `_build_diarization_metadata_payload` and replaced it with a thin delegate to the orchestrator's builder. `_stage_export_artifacts` now finalizes transcript payloads via `_finalize_transcript_payload` instead of reassigning fields inline.
- `tasks/QUEUE.md`: marked PR-ARTIFACT-SINGLE-WRITER-01 as DONE.
- `tests/test_pipeline_resume_coverage.py`: added three regression tests — delegate equivalence, PR-140-style field propagation via monkeypatch, and finalizer input normalization.
- `artifacts/ci.log`, `artifacts/pr.patch`: refreshed review artifacts.

## How verified
- `INSTALL_DEPS=0 USE_VENV=0 bash scripts/ci.sh` → exit 0, 1167 passed / 3 skipped, 100% combined coverage, `lan_transcriber` 100%, `lan_app` 100%.

## Artifacts
- artifacts/ci.log
- artifacts/pr.patch

## Manual test steps
- N/A — pure library refactor backed by unit + integration coverage.

## MCP usage
- None

@codex review