### PR TITLE
PR-SPEAKER-MERGE-DUAL-THRESHOLD-01: Dual similarity threshold for speaker merge

### DIFF
--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -104,8 +104,8 @@ Requirement already satisfied: pytz>2021.1 in /home/alexey/.pyenv/versions/3.11.
 Building wheels for collected packages: lan-transcriber
   Building editable for lan-transcriber (pyproject.toml): started
   Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
-  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=91741c2375a8bd8d308b55920a9d38e33e1f546861079cbc9726e305bfdccd24
-  Stored in directory: /tmp/pip-ephem-wheel-cache-e1p3eafk/wheels/3c/34/21/7d1a99d2a9e86cdb0d7c14d1c0d7dc5a97e0d170dff3df8fb1
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=7bd0fd13b8010751a4094a4fa7b4e85244306e42334b91a978c0530c3c2255fb
+  Stored in directory: /tmp/pip-ephem-wheel-cache-1r7ju4l8/wheels/3c/34/21/7d1a99d2a9e86cdb0d7c14d1c0d7dc5a97e0d170dff3df8fb1
 Successfully built lan-transcriber
 Installing collected packages: lan-transcriber
   Attempting uninstall: lan-transcriber
@@ -119,36 +119,36 @@ All checks passed!
 The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
 
   warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
-........................................................................ [  6%]
-........................................................................ [ 12%]
-........................................................................ [ 18%]
-........................................................................ [ 24%]
-........................................................................ [ 30%]
-........................................................................ [ 36%]
-........................................................................ [ 42%]
-........................................................................ [ 48%]
-........................................................................ [ 54%]
-........................................................................ [ 60%]
-........................................................................ [ 66%]
-........................................................................ [ 72%]
-.....................s.................................................. [ 78%]
-........................................................................ [ 84%]
-........................................................................ [ 90%]
-........................................................................ [ 96%]
-............................................                             [100%]
+........................................................................ [  5%]
+........................................................................ [ 11%]
+........................................................................ [ 17%]
+........................................................................ [ 23%]
+........................................................................ [ 29%]
+........................................................................ [ 35%]
+........................................................................ [ 41%]
+........................................................................ [ 47%]
+........................................................................ [ 53%]
+........................................................................ [ 59%]
+........................................................................ [ 65%]
+........................................................................ [ 71%]
+.....................s.................................................. [ 77%]
+........................................................................ [ 83%]
+........................................................................ [ 89%]
+........................................................................ [ 95%]
+.................................................                        [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
     import audioop
 
-lan_transcriber/pipeline_steps/orchestrator.py:259
+lan_transcriber/pipeline_steps/orchestrator.py:260
 tests/test_imports.py::test_imports[lan_transcriber.pipeline_steps.orchestrator]
 tests/test_imports.py::test_orchestrator_import_does_not_import_whisperx
-  /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/orchestrator.py:259: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
+  /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/orchestrator.py:260: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
     class Settings(BaseSettings):
 
-lan_app/config.py:53
-  /home/alexey/LAN_Transcriber/lan_app/config.py:53: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
+lan_app/config.py:54
+  /home/alexey/LAN_Transcriber/lan_app/config.py:54: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
     class AppSettings(BaseSettings):
 
 tests/test_cov_lan_app_health_worker.py::test_healthchecks_module_main_guard
@@ -174,13 +174,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.11.9-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   14642      0   4902      0   100%
+TOTAL   14651      0   4904      0   100%
 
 64 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1195 passed, 3 skipped, 11 warnings in 108.45s (0:01:48)
+1200 passed, 3 skipped, 11 warnings in 104.83s (0:01:44)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -203,17 +203,17 @@ lan_transcriber/pipeline_steps/artifacts.py                19      0      0     
 lan_transcriber/pipeline_steps/diarization_quality.py     318      0    120      0   100%
 lan_transcriber/pipeline_steps/language.py                155      0     64      0   100%
 lan_transcriber/pipeline_steps/multilingual_asr.py        239      0     88      0   100%
-lan_transcriber/pipeline_steps/orchestrator.py           1298      0    380      0   100%
+lan_transcriber/pipeline_steps/orchestrator.py           1299      0    380      0   100%
 lan_transcriber/pipeline_steps/precheck.py                116      0     46      0   100%
 lan_transcriber/pipeline_steps/snippets.py                231      0     84      0   100%
-lan_transcriber/pipeline_steps/speaker_merge.py           219      0    104      0   100%
+lan_transcriber/pipeline_steps/speaker_merge.py           226      0    106      0   100%
 lan_transcriber/pipeline_steps/speaker_turns.py           267      0    134      0   100%
 lan_transcriber/pipeline_steps/summary_builder.py         276      0     98      0   100%
 lan_transcriber/runtime_paths.py                           21      0      4      0   100%
 lan_transcriber/torch_safe_globals.py                     126      0     40      0   100%
 lan_transcriber/utils.py                                   50      0     30      0   100%
 -----------------------------------------------------------------------------------------
-TOTAL                                                    4539      0   1564      0   100%
+TOTAL                                                    4547      0   1566      0   100%
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%
@@ -224,7 +224,7 @@ lan_app/calendar/__init__.py           4      0      0      0   100%
 lan_app/calendar/ics.py              235      0     88      0   100%
 lan_app/calendar/matching.py         333      0    132      0   100%
 lan_app/calendar/service.py           66      0     12      0   100%
-lan_app/config.py                    116      0     16      0   100%
+lan_app/config.py                    117      0     16      0   100%
 lan_app/constants.py                  30      0      0      0   100%
 lan_app/conversation_metrics.py      380      0    150      0   100%
 lan_app/db.py                       1449      0    322      0   100%
@@ -252,4 +252,4 @@ lan_app/worker.py                     28      0      2      0   100%
 lan_app/worker_tasks.py             1734      0    498      0   100%
 lan_app/workers.py                    10      0      0      0   100%
 --------------------------------------------------------------------
-TOTAL                              10103      0   3338      0   100%
+TOTAL                              10104      0   3338      0   100%

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,139 +1,435 @@
+diff --git a/lan_app/config.py b/lan_app/config.py
+index 72275c8..2227893 100644
+--- a/lan_app/config.py
++++ b/lan_app/config.py
+@@ -19,6 +19,7 @@ from lan_transcriber.pipeline_steps.diarization_quality import (
+ )
+ from lan_transcriber.pipeline_steps.speaker_merge import (
+     DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
++    DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
+     DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+ )
+ from lan_transcriber.pipeline_steps.speaker_turns import (
+@@ -381,6 +382,15 @@ class AppSettings(BaseSettings):
+             "SPEAKER_MERGE_SIMILARITY_THRESHOLD",
+         ),
+     )
++    speaker_merge_no_overlap_similarity_threshold: float = Field(
++        default=DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
++        ge=0.0,
++        le=1.0,
++        validation_alias=AliasChoices(
++            "LAN_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
++            "SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
++        ),
++    )
+     speaker_merge_max_segments: int = Field(
+         default=DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
+         ge=1,
 diff --git a/lan_app/worker_tasks.py b/lan_app/worker_tasks.py
-index a4394f0..b1dbb97 100644
+index b1dbb97..f868714 100644
 --- a/lan_app/worker_tasks.py
 +++ b/lan_app/worker_tasks.py
-@@ -4344,13 +4344,20 @@ def process_job(
-                     raise ValueError(f"Recording not found: {recording_id}")
-             _append_step_log(log_path, f"started job={job_id} type={job_type}")
+@@ -1889,6 +1889,7 @@ def _build_pipeline_settings(settings: AppSettings) -> PipelineSettings:
+         diarization_flicker_max_consecutive=settings.diarization_flicker_max_consecutive,
+         speaker_merge_enabled=settings.speaker_merge_enabled,
+         speaker_merge_similarity_threshold=settings.speaker_merge_similarity_threshold,
++        speaker_merge_no_overlap_similarity_threshold=settings.speaker_merge_no_overlap_similarity_threshold,
+         speaker_merge_max_segments=settings.speaker_merge_max_segments,
+         speaker_turn_merge_gap_sec=settings.speaker_turn_merge_gap_sec,
+         speaker_turn_short_merge_gap_sec=settings.speaker_turn_short_merge_gap_sec,
+@@ -2246,6 +2247,7 @@ def _apply_speaker_merge_step(
+                 audio_path=working_audio_path,
+                 embedding_model=embedding_model,
+                 similarity_threshold=pipeline_settings.speaker_merge_similarity_threshold,
++                no_overlap_similarity_threshold=pipeline_settings.speaker_merge_no_overlap_similarity_threshold,
+                 max_segments_per_speaker=pipeline_settings.speaker_merge_max_segments,
+             )
+             speaker_merge_diagnostics.update(merge_run_diagnostics)
+diff --git a/lan_transcriber/pipeline_steps/orchestrator.py b/lan_transcriber/pipeline_steps/orchestrator.py
+index 4e625b6..33d4f4d 100644
+--- a/lan_transcriber/pipeline_steps/orchestrator.py
++++ b/lan_transcriber/pipeline_steps/orchestrator.py
+@@ -79,6 +79,7 @@ from .diarization_quality import (
+ from .snippets import SnippetExportRequest, export_speaker_snippets, write_empty_snippets_manifest
+ from .speaker_merge import (
+     DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
++    DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
+     DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+     EmbeddingModel,
+     merge_similar_speakers,
+@@ -482,6 +483,16 @@ class Settings(BaseSettings):
+             "LAN_SPEAKER_MERGE_SIMILARITY_THRESHOLD",
+         ),
+     )
++    speaker_merge_no_overlap_similarity_threshold: float = Field(
++        default=DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
++        ge=0.0,
++        le=1.0,
++        validation_alias=AliasChoices(
++            "speaker_merge_no_overlap_similarity_threshold",
++            "SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
++            "LAN_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
++        ),
++    )
+     speaker_merge_max_segments: int = Field(
+         default=DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
+         ge=1,
+@@ -3185,6 +3196,7 @@ async def run_pipeline(
+                     audio_path=audio_path,
+                     embedding_model=embedding_model,
+                     similarity_threshold=cfg.speaker_merge_similarity_threshold,
++                    no_overlap_similarity_threshold=cfg.speaker_merge_no_overlap_similarity_threshold,
+                     max_segments_per_speaker=cfg.speaker_merge_max_segments,
+                 )
+                 speaker_merge_diagnostics.update(merge_run_diagnostics)
+diff --git a/lan_transcriber/pipeline_steps/speaker_merge.py b/lan_transcriber/pipeline_steps/speaker_merge.py
+index 976c4ae..3814d39 100644
+--- a/lan_transcriber/pipeline_steps/speaker_merge.py
++++ b/lan_transcriber/pipeline_steps/speaker_merge.py
+@@ -43,6 +43,7 @@ from lan_transcriber.utils import safe_float
+ EmbeddingModel = Callable[[Path, float, float], "Any"]
  
--            if force_reprocess and attempt == 1:
--                # Only run the destructive cleanup on the first attempt: if a
--                # later retry re-ran it, we would wipe stages that the retry
--                # had already re-executed successfully. Failing to clean up on
--                # the first attempt fails the job outright, which is the
--                # recoverable outcome (the user can trigger force reprocess
--                # again, which mints a fresh job id).
-+            if force_reprocess:
-+                # Run cleanup on EVERY attempt, not just the first: if an
-+                # earlier attempt failed after partial progress, a retry must
-+                # wipe that partial state and restart from a fully-cleared
-+                # pipeline, not resume against stale files. The ops are
-+                # idempotent — on the second attempt clear_derived_artifacts
-+                # only deletes whatever (if anything) the retry has recreated,
-+                # and clear_recording_pipeline_stages(from_stage="precheck")
-+                # still preserves the sanitize_audio row so sanitization is
-+                # skipped exactly the same way across retries. Skipping the
-+                # cleanup on a retry after a cleanup failure would let
-+                # _run_precheck_pipeline silently run against partially
-+                # cleared state and report success without honoring the
-+                # force-reprocess contract.
-                 try:
-                     _apply_force_reprocess_cleanup(
-                         recording_id=recording_id,
-diff --git a/tests/test_db_queue.py b/tests/test_db_queue.py
-index ea8da07..e1093ea 100644
---- a/tests/test_db_queue.py
-+++ b/tests/test_db_queue.py
-@@ -1370,6 +1370,102 @@ def test_apply_force_reprocess_cleanup_swallows_log_ioerror(
-     assert not (derived / "summary.json").exists()
+ DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD = 0.80
++DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD = 0.70
+ DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS = 5
+ DEFAULT_SPEAKER_MERGE_SEGMENT_DURATION_SEC = 3.0
+ DEFAULT_SPEAKER_MERGE_OVERLAP_TOLERANCE_SEC = 0.1
+@@ -339,6 +340,7 @@ def merge_similar_speakers(
+     audio_path: Path,
+     embedding_model: EmbeddingModel | None,
+     similarity_threshold: float = DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
++    no_overlap_similarity_threshold: float = DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
+     max_segments_per_speaker: int = DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
+     segment_duration_sec: float = DEFAULT_SPEAKER_MERGE_SEGMENT_DURATION_SEC,
+     overlap_tolerance_sec: float = DEFAULT_SPEAKER_MERGE_OVERLAP_TOLERANCE_SEC,
+@@ -407,16 +409,20 @@ def merge_similar_speakers(
+                     "similarity": float(similarity),
+                     "overlap": False,
+                     "action": "skipped_already_merged",
++                    "effective_threshold": None,
+                 }
+             )
+             continue
+-        if similarity < similarity_threshold:
++        # Pairs are sorted by similarity descending.  If below the relaxed
++        # (lower) threshold, all remaining pairs will also be below it.
++        if similarity < no_overlap_similarity_threshold:
+             _logger.info(
+-                "speaker_merge: skip %s<->%s similarity=%.3f < threshold=%.3f",
++                "speaker_merge: skip %s<->%s similarity=%.3f < "
++                "no_overlap_threshold=%.3f",
+                 left_speaker,
+                 right_speaker,
+                 similarity,
+-                similarity_threshold,
++                no_overlap_similarity_threshold,
+             )
+             diagnostics["pairwise_scores"].append(
+                 {
+@@ -425,9 +431,10 @@ def merge_similar_speakers(
+                     "similarity": float(similarity),
+                     "overlap": False,
+                     "action": "skipped_low_similarity",
++                    "effective_threshold": float(no_overlap_similarity_threshold),
+                 }
+             )
+-            continue
++            break
+         # Use a fresh copy of the original segments but with previously decided
+         # merges applied so overlap detection sees the post-merge world.
+         overlap_segments: list[dict[str, Any]] = []
+@@ -436,12 +443,37 @@ def merge_similar_speakers(
+                 merge_map, str(row.get("speaker") or "")
+             )
+             overlap_segments.append({**row, "speaker": speaker})
+-        if speakers_overlap(
++        has_overlap = speakers_overlap(
+             left_target,
+             right_target,
+             overlap_segments,
+             tolerance_sec=overlap_tolerance_sec,
+-        ):
++        )
++        effective_threshold = (
++            similarity_threshold if has_overlap else no_overlap_similarity_threshold
++        )
++        if similarity < effective_threshold:
++            _logger.info(
++                "speaker_merge: skip %s<->%s similarity=%.3f < "
++                "effective_threshold=%.3f (overlap=%s)",
++                left_speaker,
++                right_speaker,
++                similarity,
++                effective_threshold,
++                has_overlap,
++            )
++            diagnostics["pairwise_scores"].append(
++                {
++                    "speaker_a": left_speaker,
++                    "speaker_b": right_speaker,
++                    "similarity": float(similarity),
++                    "overlap": has_overlap,
++                    "action": "skipped_low_similarity",
++                    "effective_threshold": float(effective_threshold),
++                }
++            )
++            continue
++        if has_overlap:
+             _logger.info(
+                 "speaker_merge: skip %s<->%s similarity=%.3f overlap=True",
+                 left_speaker,
+@@ -455,6 +487,7 @@ def merge_similar_speakers(
+                     "similarity": float(similarity),
+                     "overlap": True,
+                     "action": "skipped_overlap",
++                    "effective_threshold": float(effective_threshold),
+                 }
+             )
+             continue
+@@ -477,6 +510,7 @@ def merge_similar_speakers(
+                 "similarity": float(similarity),
+                 "overlap": False,
+                 "action": "merged",
++                "effective_threshold": float(effective_threshold),
+             }
+         )
+         _logger.info(
+@@ -517,6 +551,7 @@ def merge_similar_speakers(
+ 
+ __all__ = [
+     "DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS",
++    "DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
+     "DEFAULT_SPEAKER_MERGE_OVERLAP_TOLERANCE_SEC",
+     "DEFAULT_SPEAKER_MERGE_SEGMENT_DURATION_SEC",
+     "DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD",
+diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
+index 59f494f..559b24e 100644
+--- a/tasks/QUEUE.md
++++ b/tasks/QUEUE.md
+@@ -726,6 +726,6 @@ Queue (in order)
+ - Depends on: PR-ARTIFACT-SINGLE-WRITER-01
+ 
+ 145) PR-SPEAKER-MERGE-DUAL-THRESHOLD-01: Dual similarity threshold for speaker merge: strict when overlap, relaxed when no overlap
+-- Status: TODO
++- Status: DOING
+ - Tasks file: tasks/PR-SPEAKER-MERGE-DUAL-THRESHOLD-01.md
+ - Depends on: PR-SPEAKER-MERGE-TORCH-LOAD-FIX-01
+diff --git a/tests/test_speaker_merge.py b/tests/test_speaker_merge.py
+index fb7cdf4..65a0428 100644
+--- a/tests/test_speaker_merge.py
++++ b/tests/test_speaker_merge.py
+@@ -12,6 +12,7 @@ import pytest
+ 
+ from lan_transcriber.pipeline_steps import orchestrator as pipeline_orchestrator
+ from lan_transcriber.pipeline_steps.speaker_merge import (
++    DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
+     DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+     compute_pairwise_similarity,
+     extract_speaker_embeddings,
+@@ -323,7 +324,7 @@ def test_no_merge_below_threshold() -> None:
+         _segment("A", 0.0, 5.0),
+         _segment("B", 6.0, 11.0),
+     ]
+-    # similarity 0.75 between A and B, below the default 0.80 threshold.
++    # similarity 0.75 between A and B, below both thresholds when set equal.
+     sim = 0.75
+     complement = math.sqrt(1.0 - sim * sim)
+     model = _make_embedding_model(
+@@ -338,6 +339,7 @@ def test_no_merge_below_threshold() -> None:
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+         similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
++        no_overlap_similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+     )
+     assert merge_map == {}
+     assert {row["speaker"] for row in updated} == {"A", "B"}
+@@ -693,6 +695,7 @@ def test_diagnostics_low_similarity() -> None:
+         audio_path=_AUDIO_PATH,
+         embedding_model=model,
+         similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
++        no_overlap_similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+     )
+     assert merge_map == {}
+     assert diagnostics["embedding_model_available"] is True
+@@ -708,6 +711,9 @@ def test_diagnostics_low_similarity() -> None:
+     assert low["similarity"] == pytest.approx(sim)
+     assert low["overlap"] is False
+     assert {low["speaker_a"], low["speaker_b"]} == {"A", "B"}
++    assert low["effective_threshold"] == pytest.approx(
++        DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD
++    )
  
  
-+def test_process_job_force_reprocess_cleanup_runs_on_every_retry(
-+    tmp_path: Path, monkeypatch
-+):
-+    """Retries must re-run cleanup so stale state can never reach the pipeline."""
-+
-+    from lan_app.db import mark_recording_pipeline_stage_completed
-+
-+    cfg = _test_settings(tmp_path)
-+    monkeypatch.setenv("LAN_DATA_ROOT", str(cfg.data_root))
-+    monkeypatch.setenv("LAN_RECORDINGS_ROOT", str(cfg.recordings_root))
-+    monkeypatch.setenv("LAN_DB_PATH", str(cfg.db_path))
-+    monkeypatch.setenv("LAN_PROM_SNAPSHOT_PATH", str(cfg.metrics_snapshot_path))
-+    monkeypatch.setenv("LAN_MAX_JOB_ATTEMPTS", "3")
-+
-+    init_db(cfg)
-+    create_recording(
-+        "rec-worker-force-retry",
-+        source="test",
-+        source_filename="retry.mp3",
-+        status=RECORDING_STATUS_QUEUED,
-+        settings=cfg,
+ def test_diagnostics_overlap() -> None:
+@@ -736,6 +742,9 @@ def test_diagnostics_overlap() -> None:
+     assert overlap_entry["overlap"] is True
+     assert overlap_entry["similarity"] == pytest.approx(1.0)
+     assert {overlap_entry["speaker_a"], overlap_entry["speaker_b"]} == {"A", "B"}
++    assert overlap_entry["effective_threshold"] == pytest.approx(
++        DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD
 +    )
-+    create_job(
-+        "job-worker-force-retry",
-+        recording_id="rec-worker-force-retry",
-+        job_type=JOB_TYPE_PRECHECK,
-+        status=JOB_STATUS_QUEUED,
-+        settings=cfg,
-+    )
-+    mark_recording_pipeline_stage_completed(
-+        "rec-worker-force-retry",
-+        stage_name="sanitize_audio",
-+        settings=cfg,
-+    )
-+    mark_recording_pipeline_stage_completed(
-+        "rec-worker-force-retry",
-+        stage_name="precheck",
-+        settings=cfg,
-+    )
-+    derived = cfg.recordings_root / "rec-worker-force-retry" / "derived"
-+    derived.mkdir(parents=True, exist_ok=True)
-+    (derived / "audio_sanitized.wav").write_bytes(b"\x00")
-+    (derived / "audio_sanitize.json").write_text("{}", encoding="utf-8")
-+    (derived / "summary.json").write_text("{}", encoding="utf-8")
-+
-+    cleanup_calls: list[int] = []
-+    real_cleanup = worker_tasks._apply_force_reprocess_cleanup
-+
-+    def _counting_cleanup(recording_id, *, settings, log_path):
-+        call_number = len(cleanup_calls) + 1
-+        cleanup_calls.append(call_number)
-+        real_cleanup(recording_id, settings=settings, log_path=log_path)
-+        if call_number == 1:
-+            # Simulate attempt 1's pipeline writing a stale partial artifact
-+            # after cleanup but before failing. The retry's cleanup must
-+            # wipe this file — that is the whole point of this test.
-+            (derived / "asr_partial.json").write_text("stale", encoding="utf-8")
-+
-+    monkeypatch.setattr(
-+        "lan_app.worker_tasks._apply_force_reprocess_cleanup",
-+        _counting_cleanup,
-+    )
-+
-+    pipeline_calls: list[int] = []
-+
-+    def _pipeline(*, recording_id, settings, log_path):
-+        pipeline_calls.append(len(pipeline_calls) + 1)
-+        if len(pipeline_calls) < 2:
-+            # First attempt fails with a retryable error so process_job retries.
-+            raise RuntimeError("transient pipeline failure")
-+        return worker_tasks.PipelineTerminalState(status=RECORDING_STATUS_READY)
-+
-+    monkeypatch.setattr("lan_app.worker_tasks._run_precheck_pipeline", _pipeline)
-+    monkeypatch.setattr("lan_app.worker_tasks.time.sleep", lambda _s: None)
-+
-+    result = process_job(
-+        "job-worker-force-retry",
-+        "rec-worker-force-retry",
-+        JOB_TYPE_PRECHECK,
-+        force_reprocess=True,
-+    )
-+
-+    assert result["status"] == "ok"
-+    # Cleanup must have run on both the first attempt AND the retry so that
-+    # stale partial-progress state is wiped before every pipeline invocation.
-+    assert cleanup_calls == [1, 2]
-+    assert pipeline_calls == [1, 2]
-+    # Sanitize outputs survive every cleanup pass; the stale partial from
-+    # attempt 1 has been wiped by attempt 2's cleanup so the pipeline ran
-+    # against a fully-clean state, not the leftover from the first attempt.
-+    assert (derived / "audio_sanitized.wav").exists()
-+    assert (derived / "audio_sanitize.json").exists()
-+    assert not (derived / "asr_partial.json").exists()
-+    assert not (derived / "summary.json").exists()
-+
-+
- def test_process_job_force_reprocess_wraps_clear_errors(tmp_path: Path, monkeypatch):
-     from lan_app.ops import ClearDerivedArtifactsError
  
+ 
+ def test_diagnostics_merged() -> None:
+@@ -764,11 +773,160 @@ def test_diagnostics_merged() -> None:
+     assert entry["overlap"] is False
+     assert entry["similarity"] == pytest.approx(1.0)
+     assert {entry["speaker_a"], entry["speaker_b"]} == {"A", "B"}
++    assert entry["effective_threshold"] == pytest.approx(
++        DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD
++    )
+     assert diagnostics["merges_applied"] == merge_map
+     assert diagnostics["centroids_computed"] == ["A", "B"]
+     assert diagnostics["speakers_found"] == ["A", "B"]
+ 
+ 
++def test_merge_relaxed_threshold_no_overlap() -> None:
++    """similarity=0.75, no overlap, strict=0.80, relaxed=0.70 -> MERGE."""
++    diar_segments = [
++        _segment("A", 0.0, 5.0),
++        _segment("B", 6.0, 11.0),
++    ]
++    sim = 0.75
++    complement = math.sqrt(1.0 - sim * sim)
++    model = _make_embedding_model(
++        {"A": [1.0, 0.0], "B": [sim, complement]},
++        {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
++    )
++    updated, merge_map, diag = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=model,
++        similarity_threshold=0.80,
++        no_overlap_similarity_threshold=0.70,
++    )
++    assert merge_map  # merged
++    assert len({row["speaker"] for row in updated}) == 1
++    merged_entry = next(
++        e for e in diag["pairwise_scores"] if e["action"] == "merged"
++    )
++    assert merged_entry["effective_threshold"] == pytest.approx(0.70)
++
++
++def test_no_merge_strict_threshold_with_overlap() -> None:
++    """similarity=0.85, overlap=true -> NOT MERGED (overlap blocks)."""
++    diar_segments = [
++        _segment("A", 0.0, 5.0),
++        _segment("B", 2.0, 7.0),  # overlaps with A
++    ]
++    sim = 0.85
++    complement = math.sqrt(1.0 - sim * sim)
++    model = _make_embedding_model(
++        {"A": [1.0, 0.0], "B": [sim, complement]},
++        {"A": [(0.0, 5.0)], "B": [(2.0, 7.0)]},
++    )
++    updated, merge_map, diag = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=model,
++        similarity_threshold=0.80,
++        no_overlap_similarity_threshold=0.70,
++    )
++    assert merge_map == {}
++    assert {row["speaker"] for row in updated} == {"A", "B"}
++    overlap_entry = next(
++        e for e in diag["pairwise_scores"] if e["action"] == "skipped_overlap"
++    )
++    assert overlap_entry["overlap"] is True
++    assert overlap_entry["effective_threshold"] == pytest.approx(0.80)
++
++
++def test_no_merge_between_thresholds_with_overlap() -> None:
++    """similarity=0.75, overlap=true, strict=0.80, relaxed=0.70.
++
++    The pair passes the relaxed guard (0.75 >= 0.70), but overlap pushes
++    the effective threshold to 0.80, and 0.75 < 0.80 -> skipped.
++    """
++    diar_segments = [
++        _segment("A", 0.0, 5.0),
++        _segment("B", 2.0, 7.0),  # overlaps with A
++    ]
++    sim = 0.75
++    complement = math.sqrt(1.0 - sim * sim)
++    model = _make_embedding_model(
++        {"A": [1.0, 0.0], "B": [sim, complement]},
++        {"A": [(0.0, 5.0)], "B": [(2.0, 7.0)]},
++    )
++    updated, merge_map, diag = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=model,
++        similarity_threshold=0.80,
++        no_overlap_similarity_threshold=0.70,
++    )
++    assert merge_map == {}
++    assert {row["speaker"] for row in updated} == {"A", "B"}
++    low_entry = next(
++        e for e in diag["pairwise_scores"] if e["action"] == "skipped_low_similarity"
++    )
++    assert low_entry["overlap"] is True
++    assert low_entry["effective_threshold"] == pytest.approx(0.80)
++
++
++def test_no_merge_below_relaxed_threshold() -> None:
++    """similarity=0.65, no overlap, relaxed=0.70 -> NOT MERGED."""
++    diar_segments = [
++        _segment("A", 0.0, 5.0),
++        _segment("B", 6.0, 11.0),
++    ]
++    sim = 0.65
++    complement = math.sqrt(1.0 - sim * sim)
++    model = _make_embedding_model(
++        {"A": [1.0, 0.0], "B": [sim, complement]},
++        {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
++    )
++    updated, merge_map, diag = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=model,
++        similarity_threshold=0.80,
++        no_overlap_similarity_threshold=0.70,
++    )
++    assert merge_map == {}
++    assert {row["speaker"] for row in updated} == {"A", "B"}
++    low_entry = next(
++        e for e in diag["pairwise_scores"] if e["action"] == "skipped_low_similarity"
++    )
++    assert low_entry["effective_threshold"] == pytest.approx(0.70)
++
++
++def test_real_case_0786_merges_with_dual_threshold() -> None:
++    """Exact Plaud case: similarity=0.786, no overlap, strict=0.80, relaxed=0.70.
++
++    Before this change the pair was skipped (0.786 < 0.80). With the relaxed
++    no-overlap threshold (0.70) and no temporal overlap, it must now merge.
++    """
++    diar_segments = [
++        _segment("SPEAKER_00", 0.0, 120.0),
++        _segment("SPEAKER_01", 130.0, 250.0),
++    ]
++    sim = 0.786
++    complement = math.sqrt(1.0 - sim * sim)
++    model = _make_embedding_model(
++        {"SPEAKER_00": [1.0, 0.0], "SPEAKER_01": [sim, complement]},
++        {"SPEAKER_00": [(0.0, 120.0)], "SPEAKER_01": [(130.0, 250.0)]},
++    )
++    updated, merge_map, diag = merge_similar_speakers(
++        diar_segments,
++        audio_path=_AUDIO_PATH,
++        embedding_model=model,
++        similarity_threshold=0.80,
++        no_overlap_similarity_threshold=0.70,
++    )
++    assert merge_map  # merged
++    assert len({row["speaker"] for row in updated}) == 1
++    merged_entry = next(
++        e for e in diag["pairwise_scores"] if e["action"] == "merged"
++    )
++    assert merged_entry["similarity"] == pytest.approx(sim, abs=0.01)
++    assert merged_entry["effective_threshold"] == pytest.approx(0.70)
++
++
+ def test_diagnostics_no_model() -> None:
+     diar_segments = [
+         _segment("A", 0.0, 5.0),

--- a/lan_app/config.py
+++ b/lan_app/config.py
@@ -19,6 +19,7 @@ from lan_transcriber.pipeline_steps.diarization_quality import (
 )
 from lan_transcriber.pipeline_steps.speaker_merge import (
     DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
+    DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
     DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
 )
 from lan_transcriber.pipeline_steps.speaker_turns import (
@@ -379,6 +380,15 @@ class AppSettings(BaseSettings):
         validation_alias=AliasChoices(
             "LAN_SPEAKER_MERGE_SIMILARITY_THRESHOLD",
             "SPEAKER_MERGE_SIMILARITY_THRESHOLD",
+        ),
+    )
+    speaker_merge_no_overlap_similarity_threshold: float = Field(
+        default=DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices(
+            "LAN_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
+            "SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
         ),
     )
     speaker_merge_max_segments: int = Field(

--- a/lan_app/worker_tasks.py
+++ b/lan_app/worker_tasks.py
@@ -1889,6 +1889,7 @@ def _build_pipeline_settings(settings: AppSettings) -> PipelineSettings:
         diarization_flicker_max_consecutive=settings.diarization_flicker_max_consecutive,
         speaker_merge_enabled=settings.speaker_merge_enabled,
         speaker_merge_similarity_threshold=settings.speaker_merge_similarity_threshold,
+        speaker_merge_no_overlap_similarity_threshold=settings.speaker_merge_no_overlap_similarity_threshold,
         speaker_merge_max_segments=settings.speaker_merge_max_segments,
         speaker_turn_merge_gap_sec=settings.speaker_turn_merge_gap_sec,
         speaker_turn_short_merge_gap_sec=settings.speaker_turn_short_merge_gap_sec,
@@ -2246,6 +2247,7 @@ def _apply_speaker_merge_step(
                 audio_path=working_audio_path,
                 embedding_model=embedding_model,
                 similarity_threshold=pipeline_settings.speaker_merge_similarity_threshold,
+                no_overlap_similarity_threshold=pipeline_settings.speaker_merge_no_overlap_similarity_threshold,
                 max_segments_per_speaker=pipeline_settings.speaker_merge_max_segments,
             )
             speaker_merge_diagnostics.update(merge_run_diagnostics)

--- a/lan_transcriber/pipeline_steps/orchestrator.py
+++ b/lan_transcriber/pipeline_steps/orchestrator.py
@@ -79,6 +79,7 @@ from .diarization_quality import (
 from .snippets import SnippetExportRequest, export_speaker_snippets, write_empty_snippets_manifest
 from .speaker_merge import (
     DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
+    DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
     DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
     EmbeddingModel,
     merge_similar_speakers,
@@ -480,6 +481,16 @@ class Settings(BaseSettings):
             "speaker_merge_similarity_threshold",
             "SPEAKER_MERGE_SIMILARITY_THRESHOLD",
             "LAN_SPEAKER_MERGE_SIMILARITY_THRESHOLD",
+        ),
+    )
+    speaker_merge_no_overlap_similarity_threshold: float = Field(
+        default=DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices(
+            "speaker_merge_no_overlap_similarity_threshold",
+            "SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
+            "LAN_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
         ),
     )
     speaker_merge_max_segments: int = Field(
@@ -3185,6 +3196,7 @@ async def run_pipeline(
                     audio_path=audio_path,
                     embedding_model=embedding_model,
                     similarity_threshold=cfg.speaker_merge_similarity_threshold,
+                    no_overlap_similarity_threshold=cfg.speaker_merge_no_overlap_similarity_threshold,
                     max_segments_per_speaker=cfg.speaker_merge_max_segments,
                 )
                 speaker_merge_diagnostics.update(merge_run_diagnostics)

--- a/lan_transcriber/pipeline_steps/speaker_merge.py
+++ b/lan_transcriber/pipeline_steps/speaker_merge.py
@@ -43,6 +43,7 @@ from lan_transcriber.utils import safe_float
 EmbeddingModel = Callable[[Path, float, float], "Any"]
 
 DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD = 0.80
+DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD = 0.70
 DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS = 5
 DEFAULT_SPEAKER_MERGE_SEGMENT_DURATION_SEC = 3.0
 DEFAULT_SPEAKER_MERGE_OVERLAP_TOLERANCE_SEC = 0.1
@@ -339,6 +340,7 @@ def merge_similar_speakers(
     audio_path: Path,
     embedding_model: EmbeddingModel | None,
     similarity_threshold: float = DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+    no_overlap_similarity_threshold: float = DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
     max_segments_per_speaker: int = DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS,
     segment_duration_sec: float = DEFAULT_SPEAKER_MERGE_SEGMENT_DURATION_SEC,
     overlap_tolerance_sec: float = DEFAULT_SPEAKER_MERGE_OVERLAP_TOLERANCE_SEC,
@@ -407,16 +409,20 @@ def merge_similar_speakers(
                     "similarity": float(similarity),
                     "overlap": False,
                     "action": "skipped_already_merged",
+                    "effective_threshold": None,
                 }
             )
             continue
-        if similarity < similarity_threshold:
+        # Pairs are sorted by similarity descending.  If below the relaxed
+        # (lower) threshold, all remaining pairs will also be below it.
+        if similarity < no_overlap_similarity_threshold:
             _logger.info(
-                "speaker_merge: skip %s<->%s similarity=%.3f < threshold=%.3f",
+                "speaker_merge: skip %s<->%s similarity=%.3f < "
+                "no_overlap_threshold=%.3f",
                 left_speaker,
                 right_speaker,
                 similarity,
-                similarity_threshold,
+                no_overlap_similarity_threshold,
             )
             diagnostics["pairwise_scores"].append(
                 {
@@ -425,9 +431,10 @@ def merge_similar_speakers(
                     "similarity": float(similarity),
                     "overlap": False,
                     "action": "skipped_low_similarity",
+                    "effective_threshold": float(no_overlap_similarity_threshold),
                 }
             )
-            continue
+            break
         # Use a fresh copy of the original segments but with previously decided
         # merges applied so overlap detection sees the post-merge world.
         overlap_segments: list[dict[str, Any]] = []
@@ -436,12 +443,37 @@ def merge_similar_speakers(
                 merge_map, str(row.get("speaker") or "")
             )
             overlap_segments.append({**row, "speaker": speaker})
-        if speakers_overlap(
+        has_overlap = speakers_overlap(
             left_target,
             right_target,
             overlap_segments,
             tolerance_sec=overlap_tolerance_sec,
-        ):
+        )
+        effective_threshold = (
+            similarity_threshold if has_overlap else no_overlap_similarity_threshold
+        )
+        if similarity < effective_threshold:
+            _logger.info(
+                "speaker_merge: skip %s<->%s similarity=%.3f < "
+                "effective_threshold=%.3f (overlap=%s)",
+                left_speaker,
+                right_speaker,
+                similarity,
+                effective_threshold,
+                has_overlap,
+            )
+            diagnostics["pairwise_scores"].append(
+                {
+                    "speaker_a": left_speaker,
+                    "speaker_b": right_speaker,
+                    "similarity": float(similarity),
+                    "overlap": has_overlap,
+                    "action": "skipped_low_similarity",
+                    "effective_threshold": float(effective_threshold),
+                }
+            )
+            continue
+        if has_overlap:
             _logger.info(
                 "speaker_merge: skip %s<->%s similarity=%.3f overlap=True",
                 left_speaker,
@@ -455,6 +487,7 @@ def merge_similar_speakers(
                     "similarity": float(similarity),
                     "overlap": True,
                     "action": "skipped_overlap",
+                    "effective_threshold": float(effective_threshold),
                 }
             )
             continue
@@ -477,6 +510,7 @@ def merge_similar_speakers(
                 "similarity": float(similarity),
                 "overlap": False,
                 "action": "merged",
+                "effective_threshold": float(effective_threshold),
             }
         )
         _logger.info(
@@ -517,6 +551,7 @@ def merge_similar_speakers(
 
 __all__ = [
     "DEFAULT_SPEAKER_MERGE_MAX_SEGMENTS",
+    "DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD",
     "DEFAULT_SPEAKER_MERGE_OVERLAP_TOLERANCE_SEC",
     "DEFAULT_SPEAKER_MERGE_SEGMENT_DURATION_SEC",
     "DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD",

--- a/tasks/QUEUE.md
+++ b/tasks/QUEUE.md
@@ -726,6 +726,6 @@ Queue (in order)
 - Depends on: PR-ARTIFACT-SINGLE-WRITER-01
 
 145) PR-SPEAKER-MERGE-DUAL-THRESHOLD-01: Dual similarity threshold for speaker merge: strict when overlap, relaxed when no overlap
-- Status: TODO
+- Status: DONE
 - Tasks file: tasks/PR-SPEAKER-MERGE-DUAL-THRESHOLD-01.md
 - Depends on: PR-SPEAKER-MERGE-TORCH-LOAD-FIX-01

--- a/tests/test_speaker_merge.py
+++ b/tests/test_speaker_merge.py
@@ -12,6 +12,7 @@ import pytest
 
 from lan_transcriber.pipeline_steps import orchestrator as pipeline_orchestrator
 from lan_transcriber.pipeline_steps.speaker_merge import (
+    DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD,
     DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
     compute_pairwise_similarity,
     extract_speaker_embeddings,
@@ -323,7 +324,7 @@ def test_no_merge_below_threshold() -> None:
         _segment("A", 0.0, 5.0),
         _segment("B", 6.0, 11.0),
     ]
-    # similarity 0.75 between A and B, below the default 0.80 threshold.
+    # similarity 0.75 between A and B, below both thresholds when set equal.
     sim = 0.75
     complement = math.sqrt(1.0 - sim * sim)
     model = _make_embedding_model(
@@ -338,6 +339,7 @@ def test_no_merge_below_threshold() -> None:
         audio_path=_AUDIO_PATH,
         embedding_model=model,
         similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+        no_overlap_similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
     )
     assert merge_map == {}
     assert {row["speaker"] for row in updated} == {"A", "B"}
@@ -693,6 +695,7 @@ def test_diagnostics_low_similarity() -> None:
         audio_path=_AUDIO_PATH,
         embedding_model=model,
         similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
+        no_overlap_similarity_threshold=DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD,
     )
     assert merge_map == {}
     assert diagnostics["embedding_model_available"] is True
@@ -708,6 +711,9 @@ def test_diagnostics_low_similarity() -> None:
     assert low["similarity"] == pytest.approx(sim)
     assert low["overlap"] is False
     assert {low["speaker_a"], low["speaker_b"]} == {"A", "B"}
+    assert low["effective_threshold"] == pytest.approx(
+        DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD
+    )
 
 
 def test_diagnostics_overlap() -> None:
@@ -736,6 +742,9 @@ def test_diagnostics_overlap() -> None:
     assert overlap_entry["overlap"] is True
     assert overlap_entry["similarity"] == pytest.approx(1.0)
     assert {overlap_entry["speaker_a"], overlap_entry["speaker_b"]} == {"A", "B"}
+    assert overlap_entry["effective_threshold"] == pytest.approx(
+        DEFAULT_SPEAKER_MERGE_SIMILARITY_THRESHOLD
+    )
 
 
 def test_diagnostics_merged() -> None:
@@ -764,9 +773,158 @@ def test_diagnostics_merged() -> None:
     assert entry["overlap"] is False
     assert entry["similarity"] == pytest.approx(1.0)
     assert {entry["speaker_a"], entry["speaker_b"]} == {"A", "B"}
+    assert entry["effective_threshold"] == pytest.approx(
+        DEFAULT_SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD
+    )
     assert diagnostics["merges_applied"] == merge_map
     assert diagnostics["centroids_computed"] == ["A", "B"]
     assert diagnostics["speakers_found"] == ["A", "B"]
+
+
+def test_merge_relaxed_threshold_no_overlap() -> None:
+    """similarity=0.75, no overlap, strict=0.80, relaxed=0.70 -> MERGE."""
+    diar_segments = [
+        _segment("A", 0.0, 5.0),
+        _segment("B", 6.0, 11.0),
+    ]
+    sim = 0.75
+    complement = math.sqrt(1.0 - sim * sim)
+    model = _make_embedding_model(
+        {"A": [1.0, 0.0], "B": [sim, complement]},
+        {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
+    )
+    updated, merge_map, diag = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=model,
+        similarity_threshold=0.80,
+        no_overlap_similarity_threshold=0.70,
+    )
+    assert merge_map  # merged
+    assert len({row["speaker"] for row in updated}) == 1
+    merged_entry = next(
+        e for e in diag["pairwise_scores"] if e["action"] == "merged"
+    )
+    assert merged_entry["effective_threshold"] == pytest.approx(0.70)
+
+
+def test_no_merge_strict_threshold_with_overlap() -> None:
+    """similarity=0.85, overlap=true -> NOT MERGED (overlap blocks)."""
+    diar_segments = [
+        _segment("A", 0.0, 5.0),
+        _segment("B", 2.0, 7.0),  # overlaps with A
+    ]
+    sim = 0.85
+    complement = math.sqrt(1.0 - sim * sim)
+    model = _make_embedding_model(
+        {"A": [1.0, 0.0], "B": [sim, complement]},
+        {"A": [(0.0, 5.0)], "B": [(2.0, 7.0)]},
+    )
+    updated, merge_map, diag = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=model,
+        similarity_threshold=0.80,
+        no_overlap_similarity_threshold=0.70,
+    )
+    assert merge_map == {}
+    assert {row["speaker"] for row in updated} == {"A", "B"}
+    overlap_entry = next(
+        e for e in diag["pairwise_scores"] if e["action"] == "skipped_overlap"
+    )
+    assert overlap_entry["overlap"] is True
+    assert overlap_entry["effective_threshold"] == pytest.approx(0.80)
+
+
+def test_no_merge_between_thresholds_with_overlap() -> None:
+    """similarity=0.75, overlap=true, strict=0.80, relaxed=0.70.
+
+    The pair passes the relaxed guard (0.75 >= 0.70), but overlap pushes
+    the effective threshold to 0.80, and 0.75 < 0.80 -> skipped.
+    """
+    diar_segments = [
+        _segment("A", 0.0, 5.0),
+        _segment("B", 2.0, 7.0),  # overlaps with A
+    ]
+    sim = 0.75
+    complement = math.sqrt(1.0 - sim * sim)
+    model = _make_embedding_model(
+        {"A": [1.0, 0.0], "B": [sim, complement]},
+        {"A": [(0.0, 5.0)], "B": [(2.0, 7.0)]},
+    )
+    updated, merge_map, diag = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=model,
+        similarity_threshold=0.80,
+        no_overlap_similarity_threshold=0.70,
+    )
+    assert merge_map == {}
+    assert {row["speaker"] for row in updated} == {"A", "B"}
+    low_entry = next(
+        e for e in diag["pairwise_scores"] if e["action"] == "skipped_low_similarity"
+    )
+    assert low_entry["overlap"] is True
+    assert low_entry["effective_threshold"] == pytest.approx(0.80)
+
+
+def test_no_merge_below_relaxed_threshold() -> None:
+    """similarity=0.65, no overlap, relaxed=0.70 -> NOT MERGED."""
+    diar_segments = [
+        _segment("A", 0.0, 5.0),
+        _segment("B", 6.0, 11.0),
+    ]
+    sim = 0.65
+    complement = math.sqrt(1.0 - sim * sim)
+    model = _make_embedding_model(
+        {"A": [1.0, 0.0], "B": [sim, complement]},
+        {"A": [(0.0, 5.0)], "B": [(6.0, 11.0)]},
+    )
+    updated, merge_map, diag = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=model,
+        similarity_threshold=0.80,
+        no_overlap_similarity_threshold=0.70,
+    )
+    assert merge_map == {}
+    assert {row["speaker"] for row in updated} == {"A", "B"}
+    low_entry = next(
+        e for e in diag["pairwise_scores"] if e["action"] == "skipped_low_similarity"
+    )
+    assert low_entry["effective_threshold"] == pytest.approx(0.70)
+
+
+def test_real_case_0786_merges_with_dual_threshold() -> None:
+    """Exact Plaud case: similarity=0.786, no overlap, strict=0.80, relaxed=0.70.
+
+    Before this change the pair was skipped (0.786 < 0.80). With the relaxed
+    no-overlap threshold (0.70) and no temporal overlap, it must now merge.
+    """
+    diar_segments = [
+        _segment("SPEAKER_00", 0.0, 120.0),
+        _segment("SPEAKER_01", 130.0, 250.0),
+    ]
+    sim = 0.786
+    complement = math.sqrt(1.0 - sim * sim)
+    model = _make_embedding_model(
+        {"SPEAKER_00": [1.0, 0.0], "SPEAKER_01": [sim, complement]},
+        {"SPEAKER_00": [(0.0, 120.0)], "SPEAKER_01": [(130.0, 250.0)]},
+    )
+    updated, merge_map, diag = merge_similar_speakers(
+        diar_segments,
+        audio_path=_AUDIO_PATH,
+        embedding_model=model,
+        similarity_threshold=0.80,
+        no_overlap_similarity_threshold=0.70,
+    )
+    assert merge_map  # merged
+    assert len({row["speaker"] for row in updated}) == 1
+    merged_entry = next(
+        e for e in diag["pairwise_scores"] if e["action"] == "merged"
+    )
+    assert merged_entry["similarity"] == pytest.approx(sim, abs=0.01)
+    assert merged_entry["effective_threshold"] == pytest.approx(0.70)
 
 
 def test_diagnostics_no_model() -> None:


### PR DESCRIPTION
## Summary
- Add a second, relaxed similarity threshold (`no_overlap_similarity_threshold`, default 0.70) used when two speakers never overlap temporally
- Keep the strict threshold (0.80) for speakers that overlap — overlap still blocks merging regardless of similarity
- Fixes the real Plaud case where SPEAKER_00 and SPEAKER_01 had similarity=0.786 with zero overlap but were not merged because 0.786 < 0.80
- Both thresholds are configurable via environment variables (`SPEAKER_MERGE_NO_OVERLAP_SIMILARITY_THRESHOLD`)
- Diagnostics now include `effective_threshold` per pair showing which threshold was applied

## Test plan
- [x] `test_merge_relaxed_threshold_no_overlap` — sim=0.75, no overlap, relaxed=0.70 → MERGE
- [x] `test_no_merge_strict_threshold_with_overlap` — sim=0.85, overlap=true → NOT MERGED
- [x] `test_no_merge_between_thresholds_with_overlap` — sim=0.75, overlap=true, strict=0.80 → NOT MERGED
- [x] `test_no_merge_below_relaxed_threshold` — sim=0.65, relaxed=0.70 → NOT MERGED
- [x] `test_real_case_0786_merges_with_dual_threshold` — exact Plaud repro case → MERGE
- [x] Updated existing diagnostics tests to verify `effective_threshold` field
- [x] All 1200 tests pass, 100% statement and branch coverage

Artifacts: `artifacts/ci.log`, `artifacts/pr.patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)