### PR TITLE
PR-REMOVE-QUEUE-PAGE-01: remove Queue link from nav, keep route as hidden debug

### DIFF
--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -104,8 +104,8 @@ Requirement already satisfied: pytz>2021.1 in /home/alexey/.pyenv/versions/3.11.
 Building wheels for collected packages: lan-transcriber
   Building editable for lan-transcriber (pyproject.toml): started
   Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
-  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=6ff347444054f5c5ead06b675dc8c7d33688a180190d79a03461aa2d1439b941
-  Stored in directory: /tmp/pip-ephem-wheel-cache-7cptbjbp/wheels/3c/34/21/7d1a99d2a9e86cdb0d7c14d1c0d7dc5a97e0d170dff3df8fb1
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=bf63402e075c9aaa44a57e627cea3beb0da34538a143e14474d2239b1f2098f3
+  Stored in directory: /tmp/pip-ephem-wheel-cache-nf3sm19e/wheels/3c/34/21/7d1a99d2a9e86cdb0d7c14d1c0d7dc5a97e0d170dff3df8fb1
 Successfully built lan-transcriber
 Installing collected packages: lan-transcriber
   Attempting uninstall: lan-transcriber
@@ -181,7 +181,7 @@ TOTAL   14764      0   4936      0   100%
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1237 passed, 3 skipped, 11 warnings in 109.75s (0:01:49)
+1237 passed, 3 skipped, 11 warnings in 109.83s (0:01:49)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,0 +1,37 @@
+diff --git a/lan_app/templates/base.html b/lan_app/templates/base.html
+index 2d7c1b6..620ca4b 100644
+--- a/lan_app/templates/base.html
++++ b/lan_app/templates/base.html
+@@ -91,7 +91,6 @@ a { color: inherit; }
+       <a href="/voices" class="px-3 py-1.5 rounded text-sm font-medium {% if active=='voices' %}bg-primary/20 text-primary{% else %}text-slate-400 hover:text-white{% endif %}">Voices</a>
+       <a href="/calendars" class="px-3 py-1.5 rounded text-sm font-medium {% if active=='calendars' %}bg-primary/20 text-primary{% else %}text-slate-400 hover:text-white{% endif %}">Calendars</a>
+       <a href="/projects" class="px-3 py-1.5 rounded text-sm font-medium {% if active=='projects' %}bg-primary/20 text-primary{% else %}text-slate-400 hover:text-white{% endif %}">Projects</a>
+-      <a href="/queue" class="px-3 py-1.5 rounded text-sm font-medium {% if active=='queue' %}bg-primary/20 text-primary{% else %}text-slate-400 hover:text-white{% endif %}">Queue</a>
+     </nav>
+   </div>
+ </header>
+diff --git a/lan_app/ui_routes.py b/lan_app/ui_routes.py
+index a831b86..e9a46d6 100644
+--- a/lan_app/ui_routes.py
++++ b/lan_app/ui_routes.py
+@@ -6762,6 +6762,7 @@ async def ui_voice_sample_audio(sample_id: int) -> Any:
+ # ---------------------------------------------------------------------------
+ 
+ 
++# Hidden debug page, not linked in nav.
+ @ui_router.get("/queue", response_class=HTMLResponse)
+ async def ui_queue(
+     request: Request,
+diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
+index da2171a..9895cf3 100644
+--- a/tasks/QUEUE.md
++++ b/tasks/QUEUE.md
+@@ -746,7 +746,7 @@ Queue (in order)
+ - Depends on: PR-ASR-FORCE-TRANSCRIBE-01
+ 
+ 149) PR-REMOVE-QUEUE-PAGE-01: Remove Queue page from navigation
+-- Status: TODO
++- Status: DONE
+ - Tasks file: tasks/PR-REMOVE-QUEUE-PAGE-01.md
+ - Depends on: PR-ASR-FORCE-TRANSCRIBE-01
+ 

--- a/lan_app/templates/base.html
+++ b/lan_app/templates/base.html
@@ -91,7 +91,6 @@ a { color: inherit; }
       <a href="/voices" class="px-3 py-1.5 rounded text-sm font-medium {% if active=='voices' %}bg-primary/20 text-primary{% else %}text-slate-400 hover:text-white{% endif %}">Voices</a>
       <a href="/calendars" class="px-3 py-1.5 rounded text-sm font-medium {% if active=='calendars' %}bg-primary/20 text-primary{% else %}text-slate-400 hover:text-white{% endif %}">Calendars</a>
       <a href="/projects" class="px-3 py-1.5 rounded text-sm font-medium {% if active=='projects' %}bg-primary/20 text-primary{% else %}text-slate-400 hover:text-white{% endif %}">Projects</a>
-      <a href="/queue" class="px-3 py-1.5 rounded text-sm font-medium {% if active=='queue' %}bg-primary/20 text-primary{% else %}text-slate-400 hover:text-white{% endif %}">Queue</a>
     </nav>
   </div>
 </header>

--- a/lan_app/ui_routes.py
+++ b/lan_app/ui_routes.py
@@ -6762,6 +6762,7 @@ async def ui_voice_sample_audio(sample_id: int) -> Any:
 # ---------------------------------------------------------------------------
 
 
+# Hidden debug page, not linked in nav.
 @ui_router.get("/queue", response_class=HTMLResponse)
 async def ui_queue(
     request: Request,

--- a/tasks/QUEUE.md
+++ b/tasks/QUEUE.md
@@ -746,7 +746,7 @@ Queue (in order)
 - Depends on: PR-ASR-FORCE-TRANSCRIBE-01
 
 149) PR-REMOVE-QUEUE-PAGE-01: Remove Queue page from navigation
-- Status: TODO
+- Status: DONE
 - Tasks file: tasks/PR-REMOVE-QUEUE-PAGE-01.md
 - Depends on: PR-ASR-FORCE-TRANSCRIBE-01
 


### PR DESCRIPTION
## PR

- **PR_ID:** PR-REMOVE-QUEUE-PAGE-01
- **TASK_FILE:** [tasks/PR-REMOVE-QUEUE-PAGE-01.md](tasks/PR-REMOVE-QUEUE-PAGE-01.md)
- **Branch:** pr-remove-queue-page-01

## What changed
- Removed the **Queue** link from the top nav in [lan_app/templates/base.html](lan_app/templates/base.html) (Control Center/recording detail already surface processing status).
- Kept the `GET /queue` route in [lan_app/ui_routes.py](lan_app/ui_routes.py) and added a `# Hidden debug page, not linked in nav.` comment so it still works as a debug entry point (Option A from the task file).
- Bumped [tasks/QUEUE.md](tasks/QUEUE.md) entry 149 to `DONE`.

## How verified
- `bash scripts/ci.sh` → exit 0 (1237 passed, 3 skipped, 100% coverage).
- `bash scripts/make-review-artifacts.sh`.

## Artifacts
- [artifacts/ci.log](artifacts/ci.log)
- [artifacts/pr.patch](artifacts/pr.patch)

## Manual test steps
1. Run the app and load `/` → top nav no longer shows **Queue**; remaining links (Control Center, Corrections, Voices, Calendars, Projects) render.
2. Navigate directly to `/queue` → page still loads (hidden debug access preserved).

## MCP usage
None.

@codex review