### PR TITLE
PR-LLM-CLIENT-POOLING-01: Reuse httpx.AsyncClient across LLM requests with connection pooling and keep-alive

### DIFF
--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -104,8 +104,8 @@ Requirement already satisfied: pytz>2021.1 in ./.venv-ci/lib/python3.12/site-pac
 Building wheels for collected packages: lan-transcriber
   Building editable for lan-transcriber (pyproject.toml): started
   Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
-  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=e8b9c0753bd35e93e30750625384f86906df74f7559577309515ae7cfc366e77
-  Stored in directory: /tmp/pip-ephem-wheel-cache-gbyt8ldh/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=07691018dd0d99d6854394892d1bfb0f72edce96151d56391dda46cfac0e6301
+  Stored in directory: /tmp/pip-ephem-wheel-cache-nc6lltz3/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
 Successfully built lan-transcriber
 Installing collected packages: lan-transcriber
   Attempting uninstall: lan-transcriber
@@ -132,12 +132,12 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [ 60%]
 ........................................................................ [ 66%]
 ........................................................................ [ 71%]
-..........s............................................................. [ 77%]
+.............s.......................................................... [ 77%]
 ........................................................................ [ 82%]
 ........................................................................ [ 88%]
-........................................................................ [ 94%]
+........................................................................ [ 93%]
 ........................................................................ [ 99%]
-......                                                                   [100%]
+.........                                                                [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -176,13 +176,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.12.3-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   15052      0   5036      0   100%
+TOTAL   15120      0   5046      0   100%
 
 66 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1301 passed, 2 skipped, 11 warnings in 136.92s (0:02:16)
+1304 passed, 2 skipped, 11 warnings in 138.21s (0:02:18)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -194,7 +194,7 @@ lan_transcriber/compat/call_compat.py                      57      0     14     
 lan_transcriber/compat/pyannote_compat.py                  27      0      6      0   100%
 lan_transcriber/gpu_policy.py                             125      0     38      0   100%
 lan_transcriber/llm_chunking.py                           440      0    160      0   100%
-lan_transcriber/llm_client.py                             266      0     86      0   100%
+lan_transcriber/llm_client.py                             334      0     96      0   100%
 lan_transcriber/metrics.py                                 12      0      0      0   100%
 lan_transcriber/models.py                                  22      0      0      0   100%
 lan_transcriber/native_fixups.py                          102      0     36      0   100%
@@ -216,7 +216,7 @@ lan_transcriber/runtime_paths.py                           21      0      4     
 lan_transcriber/torch_safe_globals.py                     126      0     40      0   100%
 lan_transcriber/utils.py                                   50      0     30      0   100%
 -----------------------------------------------------------------------------------------
-TOTAL                                                    4762      0   1656      0   100%
+TOTAL                                                    4830      0   1666      0   100%
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%

--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -104,8 +104,8 @@ Requirement already satisfied: pytz>2021.1 in ./.venv-ci/lib/python3.12/site-pac
 Building wheels for collected packages: lan-transcriber
   Building editable for lan-transcriber (pyproject.toml): started
   Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
-  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=5830872cd590c8b66a2df4b962cc3ba43b837eee3a5239be0c4dedda597c4ee2
-  Stored in directory: /tmp/pip-ephem-wheel-cache-22uu8z6v/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=e8b9c0753bd35e93e30750625384f86906df74f7559577309515ae7cfc366e77
+  Stored in directory: /tmp/pip-ephem-wheel-cache-gbyt8ldh/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
 Successfully built lan-transcriber
 Installing collected packages: lan-transcriber
   Attempting uninstall: lan-transcriber
@@ -131,13 +131,13 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [ 55%]
 ........................................................................ [ 60%]
 ........................................................................ [ 66%]
-........................................................................ [ 72%]
-........s............................................................... [ 77%]
-........................................................................ [ 83%]
+........................................................................ [ 71%]
+..........s............................................................. [ 77%]
+........................................................................ [ 82%]
 ........................................................................ [ 88%]
 ........................................................................ [ 94%]
 ........................................................................ [ 99%]
-....                                                                     [100%]
+......                                                                   [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -176,13 +176,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.12.3-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   15051      0   5034      0   100%
+TOTAL   15052      0   5036      0   100%
 
 66 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1299 passed, 2 skipped, 11 warnings in 136.12s (0:02:16)
+1301 passed, 2 skipped, 11 warnings in 136.92s (0:02:16)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -194,7 +194,7 @@ lan_transcriber/compat/call_compat.py                      57      0     14     
 lan_transcriber/compat/pyannote_compat.py                  27      0      6      0   100%
 lan_transcriber/gpu_policy.py                             125      0     38      0   100%
 lan_transcriber/llm_chunking.py                           440      0    160      0   100%
-lan_transcriber/llm_client.py                             265      0     84      0   100%
+lan_transcriber/llm_client.py                             266      0     86      0   100%
 lan_transcriber/metrics.py                                 12      0      0      0   100%
 lan_transcriber/models.py                                  22      0      0      0   100%
 lan_transcriber/native_fixups.py                          102      0     36      0   100%
@@ -216,7 +216,7 @@ lan_transcriber/runtime_paths.py                           21      0      4     
 lan_transcriber/torch_safe_globals.py                     126      0     40      0   100%
 lan_transcriber/utils.py                                   50      0     30      0   100%
 -----------------------------------------------------------------------------------------
-TOTAL                                                    4761      0   1654      0   100%
+TOTAL                                                    4762      0   1656      0   100%
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%

--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -1,3 +1,119 @@
+Requirement already satisfied: pip in ./.venv-ci/lib/python3.12/site-packages (26.0.1)
+Requirement already satisfied: annotated-types==0.7.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 7)) (0.7.0)
+Requirement already satisfied: antlr4-python3-runtime==4.9.3 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 9)) (4.9.3)
+Requirement already satisfied: anyio==4.13.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 11)) (4.13.0)
+Requirement already satisfied: build==1.4.3 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 15)) (1.4.3)
+Requirement already satisfied: certifi==2026.2.25 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 17)) (2026.2.25)
+Requirement already satisfied: charset-normalizer==3.4.7 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 22)) (3.4.7)
+Requirement already satisfied: click==8.3.2 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 24)) (8.3.2)
+Requirement already satisfied: coverage==7.13.5 in ./.venv-ci/lib/python3.12/site-packages (from coverage[toml]==7.13.5->-r ci-requirements.txt (line 29)) (7.13.5)
+Requirement already satisfied: fastapi==0.116.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 31)) (0.116.1)
+Requirement already satisfied: h11==0.16.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 33)) (0.16.0)
+Requirement already satisfied: httpcore==1.0.9 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 37)) (1.0.9)
+Requirement already satisfied: httpx==0.28.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 39)) (0.28.1)
+Requirement already satisfied: icalendar==6.3.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 43)) (6.3.1)
+Requirement already satisfied: idna==3.11 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 48)) (3.11)
+Requirement already satisfied: iniconfig==2.3.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 53)) (2.3.0)
+Requirement already satisfied: omegaconf==2.3.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 55)) (2.3.0)
+Requirement already satisfied: packaging==26.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 57)) (26.0)
+Requirement already satisfied: pip-tools==7.4.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 61)) (7.4.1)
+Requirement already satisfied: pluggy==1.6.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 63)) (1.6.0)
+Requirement already satisfied: prometheus-client==0.25.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 65)) (0.25.0)
+Requirement already satisfied: pydantic==2.13.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 67)) (2.13.0)
+Requirement already satisfied: pydantic-core==2.46.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 71)) (2.46.0)
+Requirement already satisfied: pydantic-settings==2.10.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 73)) (2.10.1)
+Requirement already satisfied: pyproject-hooks==1.2.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 75)) (1.2.0)
+Requirement already satisfied: pytest==8.2.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 79)) (8.2.0)
+Requirement already satisfied: pytest-asyncio==1.1.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 85)) (1.1.0)
+Requirement already satisfied: pytest-cov==5.0.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 87)) (5.0.0)
+Requirement already satisfied: pytest-mock==3.14.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 89)) (3.14.1)
+Requirement already satisfied: python-dateutil==2.9.0.post0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 91)) (2.9.0.post0)
+Requirement already satisfied: python-dotenv==1.2.2 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 95)) (1.2.2)
+Requirement already satisfied: pyyaml==6.0.2 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 97)) (6.0.2)
+Requirement already satisfied: recurring-ical-events==3.8.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 101)) (3.8.0)
+Requirement already satisfied: requests==2.33.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 103)) (2.33.1)
+Requirement already satisfied: respx==0.22.0 in ./.venv-ci/lib/python3.12/site-packages (from respx[router]==0.22.0->-r ci-requirements.txt (line 105)) (0.22.0)
+Requirement already satisfied: ruff==0.12.4 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 107)) (0.12.4)
+Requirement already satisfied: six==1.17.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 109)) (1.17.0)
+Requirement already satisfied: starlette==0.47.3 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 111)) (0.47.3)
+Requirement already satisfied: tenacity==9.1.2 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 113)) (9.1.2)
+Requirement already satisfied: typing-extensions==4.15.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 115)) (4.15.0)
+Requirement already satisfied: typing-inspection==0.4.2 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 123)) (0.4.2)
+Requirement already satisfied: tzdata==2026.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 127)) (2026.1)
+Requirement already satisfied: urllib3==2.6.3 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 132)) (2.6.3)
+Requirement already satisfied: uvicorn==0.35.0 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 134)) (0.35.0)
+Requirement already satisfied: wheel==0.45.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 136)) (0.45.1)
+Requirement already satisfied: x-wr-timezone==2.0.1 in ./.venv-ci/lib/python3.12/site-packages (from -r ci-requirements.txt (line 140)) (2.0.1)
+Requirement already satisfied: pip>=22.2 in ./.venv-ci/lib/python3.12/site-packages (from pip-tools==7.4.1->-r ci-requirements.txt (line 61)) (26.0.1)
+Requirement already satisfied: setuptools in ./.venv-ci/lib/python3.12/site-packages (from pip-tools==7.4.1->-r ci-requirements.txt (line 61)) (82.0.0)
+WARNING: respx 0.22.0 does not provide the extra 'router'
+Obtaining file:///home/alexey/LAN_Transcriber
+  Installing build dependencies: started
+  Installing build dependencies: finished with status 'done'
+  Checking if build backend supports build_editable: started
+  Checking if build backend supports build_editable: finished with status 'done'
+  Getting requirements to build editable: started
+  Getting requirements to build editable: finished with status 'done'
+  Preparing editable metadata (pyproject.toml): started
+  Preparing editable metadata (pyproject.toml): finished with status 'done'
+Requirement already satisfied: httpx in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (0.28.1)
+Requirement already satisfied: tenacity in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (9.1.2)
+Requirement already satisfied: prometheus_client>=0.19.0 in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (0.25.0)
+Requirement already satisfied: anyio in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (4.13.0)
+Requirement already satisfied: fastapi in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (0.116.1)
+Requirement already satisfied: jinja2 in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (3.1.6)
+Requirement already satisfied: python-multipart in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (0.0.22)
+Requirement already satisfied: redis in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (7.2.0)
+Requirement already satisfied: rq in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (2.6.1)
+Requirement already satisfied: pyyaml in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (6.0.2)
+Requirement already satisfied: pydantic-settings in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (2.10.1)
+Requirement already satisfied: rapidfuzz in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (3.14.3)
+Requirement already satisfied: icalendar>=6.0 in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (6.3.1)
+Requirement already satisfied: recurring-ical-events>=3.6 in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (3.8.0)
+Requirement already satisfied: pytest in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (8.2.0)
+Requirement already satisfied: pytest-asyncio in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (1.1.0)
+Requirement already satisfied: pytest-cov in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (5.0.0)
+Requirement already satisfied: pytest-mock in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (3.14.1)
+Requirement already satisfied: respx[router] in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (0.22.0)
+Requirement already satisfied: fonttools>=4.0 in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (4.62.1)
+Requirement already satisfied: brotli in ./.venv-ci/lib/python3.12/site-packages (from lan-transcriber==0.1.0) (1.2.0)
+Requirement already satisfied: python-dateutil in ./.venv-ci/lib/python3.12/site-packages (from icalendar>=6.0->lan-transcriber==0.1.0) (2.9.0.post0)
+Requirement already satisfied: tzdata in ./.venv-ci/lib/python3.12/site-packages (from icalendar>=6.0->lan-transcriber==0.1.0) (2026.1)
+Requirement already satisfied: x-wr-timezone<3.0.0,>=1.0.0 in ./.venv-ci/lib/python3.12/site-packages (from recurring-ical-events>=3.6->lan-transcriber==0.1.0) (2.0.1)
+Requirement already satisfied: six>=1.5 in ./.venv-ci/lib/python3.12/site-packages (from python-dateutil->icalendar>=6.0->lan-transcriber==0.1.0) (1.17.0)
+Requirement already satisfied: click in ./.venv-ci/lib/python3.12/site-packages (from x-wr-timezone<3.0.0,>=1.0.0->recurring-ical-events>=3.6->lan-transcriber==0.1.0) (8.3.2)
+Requirement already satisfied: idna>=2.8 in ./.venv-ci/lib/python3.12/site-packages (from anyio->lan-transcriber==0.1.0) (3.11)
+Requirement already satisfied: typing_extensions>=4.5 in ./.venv-ci/lib/python3.12/site-packages (from anyio->lan-transcriber==0.1.0) (4.15.0)
+Requirement already satisfied: starlette<0.48.0,>=0.40.0 in ./.venv-ci/lib/python3.12/site-packages (from fastapi->lan-transcriber==0.1.0) (0.47.3)
+Requirement already satisfied: pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4 in ./.venv-ci/lib/python3.12/site-packages (from fastapi->lan-transcriber==0.1.0) (2.13.0)
+Requirement already satisfied: annotated-types>=0.6.0 in ./.venv-ci/lib/python3.12/site-packages (from pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi->lan-transcriber==0.1.0) (0.7.0)
+Requirement already satisfied: pydantic-core==2.46.0 in ./.venv-ci/lib/python3.12/site-packages (from pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi->lan-transcriber==0.1.0) (2.46.0)
+Requirement already satisfied: typing-inspection>=0.4.2 in ./.venv-ci/lib/python3.12/site-packages (from pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi->lan-transcriber==0.1.0) (0.4.2)
+Requirement already satisfied: certifi in ./.venv-ci/lib/python3.12/site-packages (from httpx->lan-transcriber==0.1.0) (2026.2.25)
+Requirement already satisfied: httpcore==1.* in ./.venv-ci/lib/python3.12/site-packages (from httpx->lan-transcriber==0.1.0) (1.0.9)
+Requirement already satisfied: h11>=0.16 in ./.venv-ci/lib/python3.12/site-packages (from httpcore==1.*->httpx->lan-transcriber==0.1.0) (0.16.0)
+Requirement already satisfied: MarkupSafe>=2.0 in ./.venv-ci/lib/python3.12/site-packages (from jinja2->lan-transcriber==0.1.0) (3.0.3)
+Requirement already satisfied: python-dotenv>=0.21.0 in ./.venv-ci/lib/python3.12/site-packages (from pydantic-settings->lan-transcriber==0.1.0) (1.2.2)
+Requirement already satisfied: iniconfig in ./.venv-ci/lib/python3.12/site-packages (from pytest->lan-transcriber==0.1.0) (2.3.0)
+Requirement already satisfied: packaging in ./.venv-ci/lib/python3.12/site-packages (from pytest->lan-transcriber==0.1.0) (26.0)
+Requirement already satisfied: pluggy<2.0,>=1.5 in ./.venv-ci/lib/python3.12/site-packages (from pytest->lan-transcriber==0.1.0) (1.6.0)
+Requirement already satisfied: coverage>=5.2.1 in ./.venv-ci/lib/python3.12/site-packages (from coverage[toml]>=5.2.1->pytest-cov->lan-transcriber==0.1.0) (7.13.5)
+WARNING: respx 0.22.0 does not provide the extra 'router'
+Requirement already satisfied: croniter in ./.venv-ci/lib/python3.12/site-packages (from rq->lan-transcriber==0.1.0) (6.0.0)
+Requirement already satisfied: pytz>2021.1 in ./.venv-ci/lib/python3.12/site-packages (from croniter->rq->lan-transcriber==0.1.0) (2025.2)
+Building wheels for collected packages: lan-transcriber
+  Building editable for lan-transcriber (pyproject.toml): started
+  Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=b244ee8d929fdd7194db59e28bfe0200dd0a4201ea5c794fb12df2e120994c40
+  Stored in directory: /tmp/pip-ephem-wheel-cache-jns9mtx5/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
+Successfully built lan-transcriber
+Installing collected packages: lan-transcriber
+  Attempting uninstall: lan-transcriber
+    Found existing installation: lan-transcriber 0.1.0
+    Uninstalling lan-transcriber-0.1.0:
+      Successfully uninstalled lan-transcriber-0.1.0
+Successfully installed lan-transcriber-0.1.0
+No broken requirements found.
 All checks passed!
 /home/alexey/LAN_Transcriber/.venv-ci/lib/python3.12/site-packages/pytest_asyncio/plugin.py:211: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
 The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
@@ -11,16 +127,17 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [ 33%]
 ........................................................................ [ 38%]
 ........................................................................ [ 44%]
-........................................................................ [ 50%]
+........................................................................ [ 49%]
 ........................................................................ [ 55%]
-........................................................................ [ 61%]
+........................................................................ [ 60%]
 ........................................................................ [ 66%]
 ........................................................................ [ 72%]
-...s.................................................................... [ 77%]
+.......s................................................................ [ 77%]
 ........................................................................ [ 83%]
 ........................................................................ [ 88%]
 ........................................................................ [ 94%]
-.......................................................................  [100%]
+........................................................................ [ 99%]
+...                                                                      [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -59,13 +176,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.12.3-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   15015      0   5024      0   100%
+TOTAL   15043      0   5030      0   100%
 
 66 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1294 passed, 2 skipped, 11 warnings in 131.94s (0:02:11)
+1298 passed, 2 skipped, 11 warnings in 131.05s (0:02:11)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -77,7 +194,7 @@ lan_transcriber/compat/call_compat.py                      57      0     14     
 lan_transcriber/compat/pyannote_compat.py                  27      0      6      0   100%
 lan_transcriber/gpu_policy.py                             125      0     38      0   100%
 lan_transcriber/llm_chunking.py                           440      0    160      0   100%
-lan_transcriber/llm_client.py                             236      0     74      0   100%
+lan_transcriber/llm_client.py                             257      0     80      0   100%
 lan_transcriber/metrics.py                                 12      0      0      0   100%
 lan_transcriber/models.py                                  22      0      0      0   100%
 lan_transcriber/native_fixups.py                          102      0     36      0   100%
@@ -99,7 +216,7 @@ lan_transcriber/runtime_paths.py                           21      0      4     
 lan_transcriber/torch_safe_globals.py                     126      0     40      0   100%
 lan_transcriber/utils.py                                   50      0     30      0   100%
 -----------------------------------------------------------------------------------------
-TOTAL                                                    4732      0   1644      0   100%
+TOTAL                                                    4753      0   1650      0   100%
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%
@@ -134,9 +251,9 @@ lan_app/tools/warm_models.py          47      0     10      0   100%
 lan_app/ui.py                         59      0     10      0   100%
 lan_app/ui_routes.py                2683      0   1020      0   100%
 lan_app/uploads.py                    79      0     14      0   100%
-lan_app/worker.py                     31      0      2      0   100%
+lan_app/worker.py                     38      0      2      0   100%
 lan_app/worker_status.py              58      0      6      0   100%
 lan_app/worker_tasks.py             1818      0    522      0   100%
 lan_app/workers.py                    10      0      0      0   100%
 --------------------------------------------------------------------
-TOTAL                              10283      0   3380      0   100%
+TOTAL                              10290      0   3380      0   100%

--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -104,8 +104,8 @@ Requirement already satisfied: pytz>2021.1 in ./.venv-ci/lib/python3.12/site-pac
 Building wheels for collected packages: lan-transcriber
   Building editable for lan-transcriber (pyproject.toml): started
   Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
-  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=b244ee8d929fdd7194db59e28bfe0200dd0a4201ea5c794fb12df2e120994c40
-  Stored in directory: /tmp/pip-ephem-wheel-cache-jns9mtx5/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=5830872cd590c8b66a2df4b962cc3ba43b837eee3a5239be0c4dedda597c4ee2
+  Stored in directory: /tmp/pip-ephem-wheel-cache-22uu8z6v/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
 Successfully built lan-transcriber
 Installing collected packages: lan-transcriber
   Attempting uninstall: lan-transcriber
@@ -132,12 +132,12 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [ 60%]
 ........................................................................ [ 66%]
 ........................................................................ [ 72%]
-.......s................................................................ [ 77%]
+........s............................................................... [ 77%]
 ........................................................................ [ 83%]
 ........................................................................ [ 88%]
 ........................................................................ [ 94%]
 ........................................................................ [ 99%]
-...                                                                      [100%]
+....                                                                     [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -176,13 +176,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.12.3-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   15043      0   5030      0   100%
+TOTAL   15051      0   5034      0   100%
 
 66 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1298 passed, 2 skipped, 11 warnings in 131.05s (0:02:11)
+1299 passed, 2 skipped, 11 warnings in 136.12s (0:02:16)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -194,7 +194,7 @@ lan_transcriber/compat/call_compat.py                      57      0     14     
 lan_transcriber/compat/pyannote_compat.py                  27      0      6      0   100%
 lan_transcriber/gpu_policy.py                             125      0     38      0   100%
 lan_transcriber/llm_chunking.py                           440      0    160      0   100%
-lan_transcriber/llm_client.py                             257      0     80      0   100%
+lan_transcriber/llm_client.py                             265      0     84      0   100%
 lan_transcriber/metrics.py                                 12      0      0      0   100%
 lan_transcriber/models.py                                  22      0      0      0   100%
 lan_transcriber/native_fixups.py                          102      0     36      0   100%
@@ -216,7 +216,7 @@ lan_transcriber/runtime_paths.py                           21      0      4     
 lan_transcriber/torch_safe_globals.py                     126      0     40      0   100%
 lan_transcriber/utils.py                                   50      0     30      0   100%
 -----------------------------------------------------------------------------------------
-TOTAL                                                    4753      0   1650      0   100%
+TOTAL                                                    4761      0   1654      0   100%
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,245 +1,496 @@
 diff --git a/lan_transcriber/llm_client.py b/lan_transcriber/llm_client.py
-index 5129b2b..abf954d 100644
+index abf954d..854c1c0 100644
 --- a/lan_transcriber/llm_client.py
 +++ b/lan_transcriber/llm_client.py
-@@ -2,11 +2,13 @@
- 
- from __future__ import annotations
- 
-+import asyncio
- import json
+@@ -7,8 +7,8 @@ import json
  import logging
  import os
  from pathlib import Path
- from typing import Any, Dict, List, Optional
-+import weakref
+-from typing import Any, Dict, List, Optional
+-import weakref
++import threading
++from typing import Any, Coroutine, Dict, List, Optional, TypeVar
  
  import anyio
  import httpx
-@@ -217,9 +219,9 @@ class LLMTruncatedResponseError(ValueError):
+@@ -23,6 +23,7 @@ _DEFAULT_LLM_MAX_TOKENS = 1024
+ _MAX_LLM_MAX_TOKENS = 4096
+ _HTTP_ERROR_BODY_MAX_CHARS = 2000
+ _logger = logging.getLogger(__name__)
++_T = TypeVar("_T")
+ 
+ 
+ def _timeout_seconds(value: str | None, *, default: float) -> float:
+@@ -219,9 +220,10 @@ class LLMTruncatedResponseError(ValueError):
  class LLMClient:
      """Simple asynchronous client for the language model API."""
  
--    _http_client: httpx.AsyncClient | None = None
--    _http_client_factory: Any = None
--    _http_client_timeout: float | None = None
-+    _http_clients: weakref.WeakKeyDictionary[
-+        asyncio.AbstractEventLoop, dict[tuple[Any, float], httpx.AsyncClient]
-+    ] = weakref.WeakKeyDictionary()
+-    _http_clients: weakref.WeakKeyDictionary[
+-        asyncio.AbstractEventLoop, dict[tuple[Any, float], httpx.AsyncClient]
+-    ] = weakref.WeakKeyDictionary()
++    _http_clients: dict[tuple[Any, float], httpx.AsyncClient] = {}
++    _http_loop: asyncio.AbstractEventLoop | None = None
++    _http_thread: threading.Thread | None = None
++    _http_runtime_lock = threading.Lock()
  
      def __init__(
          self,
-@@ -258,38 +260,34 @@ class LLMClient:
-     async def _get_client(self) -> httpx.AsyncClient:
+@@ -257,37 +259,114 @@ class LLMClient:
+         configured_mock_path = mock_response_path or os.getenv("LLM_MOCK_RESPONSE_PATH")
+         self.mock_response_path = Path(configured_mock_path) if configured_mock_path else None
+ 
+-    async def _get_client(self) -> httpx.AsyncClient:
++    @classmethod
++    def _ensure_http_runtime(cls) -> asyncio.AbstractEventLoop:
++        with cls._http_runtime_lock:
++            loop = cls._http_loop
++            thread = cls._http_thread
++            if loop is not None and thread is not None and thread.is_alive() and not loop.is_closed():
++                return loop
++
++            ready = threading.Event()
++            runtime: dict[str, asyncio.AbstractEventLoop] = {}
++
++            def _run_http_loop() -> None:
++                loop = asyncio.new_event_loop()
++                asyncio.set_event_loop(loop)
++                runtime["loop"] = loop
++                ready.set()
++                loop.run_forever()
++                loop.close()
++
++            thread = threading.Thread(
++                target=_run_http_loop,
++                name="llm-client-http-loop",
++                daemon=True,
++            )
++            cls._http_loop = None
++            cls._http_thread = thread
++            thread.start()
++            ready.wait()
++            loop = runtime["loop"]
++            cls._http_loop = loop
++            return loop
++
++    @staticmethod
++    def _running_loop() -> asyncio.AbstractEventLoop | None:
++        try:
++            return asyncio.get_running_loop()
++        except RuntimeError:
++            return None
++
++    @classmethod
++    async def _run_on_http_runtime(cls, coroutine: Coroutine[Any, Any, _T]) -> _T:
++        loop = cls._ensure_http_runtime()
++        current_loop = cls._running_loop()
++        if current_loop is loop:
++            return await coroutine
++        future = asyncio.run_coroutine_threadsafe(coroutine, loop)
++        return await asyncio.wrap_future(future)
++
++    async def _get_or_create_client(self) -> httpx.AsyncClient:
          cls = type(self)
          current_factory = httpx.AsyncClient
--        client = cls._http_client
--        client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
--        timeout_changed = cls._http_client_timeout != self.timeout
--        if (
--            client is None
--            or client_closed
--            or cls._http_client_factory is not current_factory
--            or timeout_changed
--        ):
--            if client is not None and not client_closed:
--                aclose = getattr(client, "aclose", None)
--                if callable(aclose):
--                    await aclose()
--            cls._http_client = current_factory(
-+        loop = asyncio.get_running_loop()
-+        loop_clients = cls._http_clients.setdefault(loop, {})
-+        client_key = (current_factory, self.timeout)
-+        client = loop_clients.get(client_key)
-+        if client is None or bool(getattr(client, "is_closed", False)):
-+            client = current_factory(
+-        loop = asyncio.get_running_loop()
+-        loop_clients = cls._http_clients.setdefault(loop, {})
+         client_key = (current_factory, self.timeout)
+-        client = loop_clients.get(client_key)
++        client = cls._http_clients.get(client_key)
+         if client is None or bool(getattr(client, "is_closed", False)):
+             client = current_factory(
                  timeout=httpx.Timeout(self.timeout),
                  limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
              )
--            cls._http_client_factory = current_factory
--            cls._http_client_timeout = self.timeout
--        return cls._http_client
-+            loop_clients[client_key] = client
-+        return client
+-            loop_clients[client_key] = client
++            cls._http_clients[client_key] = client
+         return client
  
++    async def _get_client(self) -> httpx.AsyncClient:
++        return await type(self)._run_on_http_runtime(self._get_or_create_client())
++
      @classmethod
-     async def close(cls) -> None:
--        client = cls._http_client
--        cls._http_client = None
--        cls._http_client_factory = None
--        cls._http_client_timeout = None
--        if client is None or bool(getattr(client, "is_closed", False)):
--            return
--        aclose = getattr(client, "aclose", None)
--        if callable(aclose):
--            await aclose()
-+        loop_clients = list(cls._http_clients.values())
-+        cls._http_clients = weakref.WeakKeyDictionary()
-+        closed_ids: set[int] = set()
-+        for pool in loop_clients:
-+            for client in pool.values():
-+                client_id = id(client)
-+                if client_id in closed_ids:
-+                    continue
-+                closed_ids.add(client_id)
-+                if client is None or bool(getattr(client, "is_closed", False)):
-+                    continue
-+                aclose = getattr(client, "aclose", None)
-+                if callable(aclose):
-+                    await aclose()
+-    async def close(cls) -> None:
+-        loop_clients = list(cls._http_clients.values())
+-        cls._http_clients = weakref.WeakKeyDictionary()
++    async def _close_clients(cls, clients: list[Any]) -> None:
++        del cls
+         closed_ids: set[int] = set()
+-        for pool in loop_clients:
+-            for client in pool.values():
+-                client_id = id(client)
+-                if client_id in closed_ids:
+-                    continue
+-                closed_ids.add(client_id)
+-                if client is None or bool(getattr(client, "is_closed", False)):
+-                    continue
+-                aclose = getattr(client, "aclose", None)
+-                if callable(aclose):
+-                    await aclose()
++        for client in clients:
++            client_id = id(client)
++            if client_id in closed_ids:
++                continue
++            closed_ids.add(client_id)
++            if client is None or bool(getattr(client, "is_closed", False)):
++                continue
++            aclose = getattr(client, "aclose", None)
++            if callable(aclose):
++                await aclose()
++
++    @classmethod
++    async def close(cls) -> None:
++        with cls._http_runtime_lock:
++            loop = cls._http_loop
++            thread = cls._http_thread
++
++        if loop is None or thread is None or not thread.is_alive() or loop.is_closed():
++            clients = list(cls._http_clients.values())
++            cls._http_clients = {}
++            await cls._close_clients(clients)
++            with cls._http_runtime_lock:
++                cls._http_loop = None
++                cls._http_thread = None
++            return
++
++        async def _shutdown_http_runtime() -> None:
++            clients = list(cls._http_clients.values())
++            cls._http_clients = {}
++            await cls._close_clients(clients)
++
++        await cls._run_on_http_runtime(_shutdown_http_runtime())
++        loop.call_soon_threadsafe(loop.stop)
++        if thread is not threading.current_thread():
++            await asyncio.to_thread(thread.join)
++        with cls._http_runtime_lock:
++            if cls._http_loop is loop:
++                cls._http_loop = None
++            if cls._http_thread is thread:
++                cls._http_thread = None
  
      @retry(
          wait=wait_exponential(multiplier=1, min=1, max=8),
+@@ -312,9 +391,12 @@ class LLMClient:
+             attempt_number if attempt_number is not None else "unknown",
+             payload.get("response_format") is not None,
+         )
+-        client = await self._get_client()
+-        with anyio.fail_after(self.timeout):
+-            resp = await client.post(url, json=payload, headers=headers)
++        async def _send_request() -> httpx.Response:
++            client = await self._get_or_create_client()
++            with anyio.fail_after(self.timeout):
++                return await client.post(url, json=payload, headers=headers)
++
++        resp = await type(self)._run_on_http_runtime(_send_request())
+         try:
+             resp.raise_for_status()
+         except httpx.HTTPStatusError as exc:
 diff --git a/tests/test_llm_client.py b/tests/test_llm_client.py
-index 103fb27..6359dad 100644
+index 6359dad..a44e128 100644
 --- a/tests/test_llm_client.py
 +++ b/tests/test_llm_client.py
-@@ -4,6 +4,7 @@ import logging
+@@ -4,7 +4,6 @@ import logging
  import pathlib
  import sys
  from typing import Any
-+import weakref
+-import weakref
  
  import httpx
  import pytest
-@@ -175,22 +176,54 @@ async def test_close_tolerates_client_without_async_close() -> None:
-     class _ClientWithoutClose:
-         is_closed = False
- 
--    llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
--    llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
--    llm_client.LLMClient._http_client_timeout = 5.0  # noqa: SLF001
-+    loop = asyncio.get_running_loop()
-+    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
-+        {loop: {("factory", 5.0): _ClientWithoutClose()}}
-+    )
-+
-+    await llm_client.LLMClient.close()
-+
-+    assert len(llm_client.LLMClient._http_clients) == 0  # noqa: SLF001
-+
-+
-+@pytest.mark.asyncio
-+async def test_close_skips_duplicate_and_already_closed_clients() -> None:
-+    loop = asyncio.get_running_loop()
-+    close_calls: list[str] = []
-+
-+    class _TrackedClient:
-+        def __init__(self, name: str, *, is_closed: bool) -> None:
-+            self.name = name
-+            self.is_closed = is_closed
-+
-+        async def aclose(self) -> None:
-+            close_calls.append(self.name)
-+            self.is_closed = True
-+
-+    shared = _TrackedClient("shared", is_closed=False)
-+    closed = _TrackedClient("closed", is_closed=True)
-+    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
-+        {
-+            loop: {
-+                ("factory-a", 1.0): shared,
-+                ("factory-b", 1.0): shared,
-+                ("factory-c", 2.0): closed,
-+            }
-+        }
-+    )
- 
-     await llm_client.LLMClient.close()
- 
--    assert llm_client.LLMClient._http_client is None  # noqa: SLF001
--    assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
--    assert llm_client.LLMClient._http_client_timeout is None  # noqa: SLF001
-+    assert close_calls == ["shared"]
-+    assert len(llm_client.LLMClient._http_clients) == 0  # noqa: SLF001
+@@ -98,8 +97,7 @@ async def test_generate_payload_includes_max_tokens() -> None:
+     assert payload["max_tokens"] == 1536
  
  
- @pytest.mark.asyncio
--async def test_post_chat_completion_recreates_shared_client_when_timeout_changes(
-+async def test_post_chat_completion_uses_separate_clients_per_event_loop(
+-@pytest.mark.asyncio
+-async def test_post_chat_completion_reuses_shared_http_client(
++def test_post_chat_completion_reuses_shared_http_client_across_asyncio_run(
      monkeypatch: pytest.MonkeyPatch,
  ) -> None:
      created_clients: list["_FakeClient"] = []
-+    active_loop = None
+@@ -133,20 +131,19 @@ async def test_post_chat_completion_reuses_shared_http_client(
+         async def aclose(self) -> None:
+             self.is_closed = True
+ 
+-    await llm_client.LLMClient.close()
+     monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
+     client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
+ 
+-    first = await client._post_chat_completion(
+-        url="http://example.test/v1/chat/completions",
+-        payload={"messages": [], "max_tokens": 111},
+-        headers={"Authorization": "Bearer secret"},
+-    )
+-    second = await client._post_chat_completion(
+-        url="http://example.test/v1/chat/completions",
+-        payload={"messages": [], "max_tokens": 222},
+-        headers={},
+-    )
++    async def _post(max_tokens: int, headers: dict[str, str]) -> dict[str, Any]:
++        return await client._post_chat_completion(
++            url="http://example.test/v1/chat/completions",
++            payload={"messages": [], "max_tokens": max_tokens},
++            headers=headers,
++        )
++
++    asyncio.run(llm_client.LLMClient.close())
++    first = asyncio.run(_post(111, {"Authorization": "Bearer secret"}))
++    second = asyncio.run(_post(222, {}))
+ 
+     assert first["choices"][0]["message"]["content"] == "ok"
+     assert second["choices"][0]["message"]["content"] == "ok"
+@@ -159,16 +156,16 @@ async def test_post_chat_completion_reuses_shared_http_client(
+     assert timeout.write == pytest.approx(0.1)
+     assert timeout.pool == pytest.approx(0.1)
+ 
+-    await llm_client.LLMClient.close()
++    asyncio.run(llm_client.LLMClient.close())
+     assert created_clients[0].is_closed is True
+-    replacement = await client._get_client()
++    replacement = asyncio.run(client._get_client())
+     assert len(created_clients) == 2
+     assert replacement is created_clients[1]
+     assert created_clients[1].kwargs["limits"] == httpx.Limits(
+         max_connections=5,
+         max_keepalive_connections=2,
+     )
+-    await llm_client.LLMClient.close()
++    asyncio.run(llm_client.LLMClient.close())
+ 
+ 
+ @pytest.mark.asyncio
+@@ -176,10 +173,7 @@ async def test_close_tolerates_client_without_async_close() -> None:
+     class _ClientWithoutClose:
+         is_closed = False
+ 
+-    loop = asyncio.get_running_loop()
+-    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
+-        {loop: {("factory", 5.0): _ClientWithoutClose()}}
+-    )
++    llm_client.LLMClient._http_clients = {("factory", 5.0): _ClientWithoutClose()}  # noqa: SLF001
+ 
+     await llm_client.LLMClient.close()
+ 
+@@ -188,7 +182,6 @@ async def test_close_tolerates_client_without_async_close() -> None:
+ 
+ @pytest.mark.asyncio
+ async def test_close_skips_duplicate_and_already_closed_clients() -> None:
+-    loop = asyncio.get_running_loop()
+     close_calls: list[str] = []
+ 
+     class _TrackedClient:
+@@ -202,15 +195,11 @@ async def test_close_skips_duplicate_and_already_closed_clients() -> None:
+ 
+     shared = _TrackedClient("shared", is_closed=False)
+     closed = _TrackedClient("closed", is_closed=True)
+-    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
+-        {
+-            loop: {
+-                ("factory-a", 1.0): shared,
+-                ("factory-b", 1.0): shared,
+-                ("factory-c", 2.0): closed,
+-            }
+-        }
+-    )
++    llm_client.LLMClient._http_clients = {  # noqa: SLF001
++        ("factory-a", 1.0): shared,
++        ("factory-b", 1.0): shared,
++        ("factory-c", 2.0): closed,
++    }
+ 
+     await llm_client.LLMClient.close()
+ 
+@@ -218,12 +207,10 @@ async def test_close_skips_duplicate_and_already_closed_clients() -> None:
+     assert len(llm_client.LLMClient._http_clients) == 0  # noqa: SLF001
+ 
+ 
+-@pytest.mark.asyncio
+-async def test_post_chat_completion_uses_separate_clients_per_event_loop(
++def test_post_chat_completion_reuses_shared_http_client_across_event_loops(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:
+     created_clients: list["_FakeClient"] = []
+-    active_loop = None
  
      class _FakeResponse:
          status_code = 200
-@@ -215,6 +248,65 @@ async def test_post_chat_completion_recreates_shared_client_when_timeout_changes
+@@ -246,34 +233,59 @@ async def test_post_chat_completion_uses_separate_clients_per_event_loop(
+         async def aclose(self) -> None:
+             self.is_closed = True
  
-     await llm_client.LLMClient.close()
+-    await llm_client.LLMClient.close()
      monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
-+    loop_one = type("LoopToken", (), {})()
-+    loop_two = type("LoopToken", (), {})()
-+
-+    def _get_running_loop():
-+        return active_loop
-+
-+    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", _get_running_loop)
+-    loop_one = type("LoopToken", (), {})()
+-    loop_two = type("LoopToken", (), {})()
 +    client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
-+
-+    active_loop = loop_one
-+    await client._post_chat_completion(
-+        url="http://example.test/v1/chat/completions",
-+        payload={"messages": [], "max_tokens": 111},
-+        headers={},
-+    )
-+    active_loop = loop_two
-+    await client._post_chat_completion(
-+        url="http://example.test/v1/chat/completions",
-+        payload={"messages": [], "max_tokens": 222},
-+        headers={},
-+    )
-+
-+    assert len(created_clients) == 2
+ 
+-    def _get_running_loop():
+-        return active_loop
++    async def _post(max_tokens: int) -> None:
++        await client._post_chat_completion(
++            url="http://example.test/v1/chat/completions",
++            payload={"messages": [], "max_tokens": max_tokens},
++            headers={},
++        )
+ 
+-    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", _get_running_loop)
+-    client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
++    asyncio.run(llm_client.LLMClient.close())
++    asyncio.run(_post(111))
++    asyncio.run(_post(222))
+ 
+-    active_loop = loop_one
+-    await client._post_chat_completion(
+-        url="http://example.test/v1/chat/completions",
+-        payload={"messages": [], "max_tokens": 111},
+-        headers={},
++    assert len(created_clients) == 1
 +    assert created_clients[0].is_closed is False
-+    assert created_clients[1].is_closed is False
-+    await llm_client.LLMClient.close()
++    asyncio.run(llm_client.LLMClient.close())
++
++
++def test_running_loop_returns_none_without_active_loop(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    def _raise_runtime_error() -> None:
++        raise RuntimeError("no running event loop")
++
++    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", _raise_runtime_error)
++
++    assert llm_client.LLMClient._running_loop() is None  # noqa: SLF001
 +
 +
 +@pytest.mark.asyncio
-+async def test_post_chat_completion_uses_separate_clients_per_timeout_without_closing_active_one(
++async def test_run_on_http_runtime_awaits_inline_when_already_on_http_loop(
 +    monkeypatch: pytest.MonkeyPatch,
 +) -> None:
-+    created_clients: list["_FakeClient"] = []
-+    loop_token = type("LoopToken", (), {})()
++    loop = asyncio.get_running_loop()
 +
-+    class _FakeResponse:
-+        status_code = 200
++    async def _inline() -> str:
++        return "inline"
 +
-+        def raise_for_status(self) -> None:
-+            return None
++    monkeypatch.setattr(
++        llm_client.LLMClient,
++        "_ensure_http_runtime",
++        classmethod(lambda cls: loop),
+     )
+-    active_loop = loop_two
+-    await client._post_chat_completion(
+-        url="http://example.test/v1/chat/completions",
+-        payload={"messages": [], "max_tokens": 222},
+-        headers={},
++    monkeypatch.setattr(
++        llm_client.LLMClient,
++        "_running_loop",
++        staticmethod(lambda: loop),
+     )
+ 
+-    assert len(created_clients) == 2
+-    assert created_clients[0].is_closed is False
+-    assert created_clients[1].is_closed is False
+-    await llm_client.LLMClient.close()
++    result = await llm_client.LLMClient._run_on_http_runtime(_inline())  # noqa: SLF001
 +
-+        def json(self) -> dict[str, object]:
-+            return {"choices": [{"message": {"content": "ok"}}]}
++    assert result == "inline"
+ 
+ 
+ @pytest.mark.asyncio
+@@ -281,7 +293,6 @@ async def test_post_chat_completion_uses_separate_clients_per_timeout_without_cl
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:
+     created_clients: list["_FakeClient"] = []
+-    loop_token = type("LoopToken", (), {})()
+ 
+     class _FakeResponse:
+         status_code = 200
+@@ -306,7 +317,6 @@ async def test_post_chat_completion_uses_separate_clients_per_timeout_without_cl
+ 
+     await llm_client.LLMClient.close()
+     monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
+-    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", lambda: loop_token)
+     fast_client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
+     slow_client = llm_client.LLMClient(base_url="http://example.test", timeout=321.0)
+ 
+@@ -329,6 +339,83 @@ async def test_post_chat_completion_uses_separate_clients_per_timeout_without_cl
+     assert created_clients[1].is_closed is True
+ 
+ 
++@pytest.mark.asyncio
++async def test_close_skips_join_and_cleanup_reset_when_runtime_state_changes(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    stop_calls: list[str] = []
 +
-+    class _FakeClient:
-+        def __init__(self, **kwargs: Any) -> None:
-+            self.kwargs = kwargs
++    class _Loop:
++        def __init__(self, name: str) -> None:
++            self.name = name
++            self.stopped = False
++
++        def is_closed(self) -> bool:
++            return False
++
++        def stop(self) -> None:
++            self.stopped = True
++
++        def call_soon_threadsafe(self, callback: Any) -> None:
++            stop_calls.append(self.name)
++            callback()
++
++    class _Thread:
++        def __init__(self, name: str) -> None:
++            self.name = name
++
++        def is_alive(self) -> bool:
++            return True
++
++    class _TrackedClient:
++        def __init__(self) -> None:
 +            self.is_closed = False
-+            created_clients.append(self)
-+
-+        async def post(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
-+            return _FakeResponse()
 +
 +        async def aclose(self) -> None:
 +            self.is_closed = True
 +
-+    await llm_client.LLMClient.close()
-+    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
-+    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", lambda: loop_token)
-     fast_client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
-     slow_client = llm_client.LLMClient(base_url="http://example.test", timeout=321.0)
- 
-@@ -230,9 +322,11 @@ async def test_post_chat_completion_recreates_shared_client_when_timeout_changes
-     )
- 
-     assert len(created_clients) == 2
--    assert created_clients[0].is_closed is True
-+    assert created_clients[0].is_closed is False
-     assert created_clients[1].kwargs["timeout"].read == pytest.approx(321.0)
-     await llm_client.LLMClient.close()
-+    assert created_clients[0].is_closed is True
-+    assert created_clients[1].is_closed is True
- 
- 
++    loop = _Loop("active")
++    replacement_loop = _Loop("replacement")
++    thread = _Thread("active")
++    replacement_thread = _Thread("replacement")
++    client = _TrackedClient()
++    original_clients = llm_client.LLMClient._http_clients  # noqa: SLF001
++    original_loop = llm_client.LLMClient._http_loop  # noqa: SLF001
++    original_thread = llm_client.LLMClient._http_thread  # noqa: SLF001
++
++    try:
++        llm_client.LLMClient._http_clients = {("factory", 1.0): client}  # noqa: SLF001
++        llm_client.LLMClient._http_loop = loop  # noqa: SLF001
++        llm_client.LLMClient._http_thread = thread  # noqa: SLF001
++
++        async def _fake_run_on_http_runtime(
++            cls: type[llm_client.LLMClient],
++            coroutine: Any,
++        ) -> None:
++            await coroutine
++            cls._http_loop = replacement_loop  # noqa: SLF001
++            cls._http_thread = replacement_thread  # noqa: SLF001
++
++        monkeypatch.setattr(
++            llm_client.LLMClient,
++            "_run_on_http_runtime",
++            classmethod(_fake_run_on_http_runtime),
++        )
++        monkeypatch.setattr(llm_client.threading, "current_thread", lambda: thread)
++
++        await llm_client.LLMClient.close()
++
++        assert client.is_closed is True
++        assert stop_calls == ["active"]
++        assert loop.stopped is True
++        assert llm_client.LLMClient._http_loop is replacement_loop  # noqa: SLF001
++        assert llm_client.LLMClient._http_thread is replacement_thread  # noqa: SLF001
++    finally:
++        llm_client.LLMClient._http_clients = original_clients  # noqa: SLF001
++        llm_client.LLMClient._http_loop = original_loop  # noqa: SLF001
++        llm_client.LLMClient._http_thread = original_thread  # noqa: SLF001
++
++
  @pytest.mark.asyncio
+ @respx.mock
+ async def test_generate_omits_model_when_not_configured() -> None:

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,164 +1,100 @@
-diff --git a/lan_app/worker.py b/lan_app/worker.py
-index 0595d06..2f032da 100644
---- a/lan_app/worker.py
-+++ b/lan_app/worker.py
-@@ -1,5 +1,6 @@
- from __future__ import annotations
- 
-+import asyncio
- import logging
- import signal
- from types import FrameType
-@@ -9,6 +10,7 @@ from rq import Worker
- 
- from .config import AppSettings
- from .db import init_db
-+from lan_transcriber.llm_client import LLMClient
- from .worker_status import start_heartbeat_thread, write_worker_status
- 
- _logger = logging.getLogger(__name__)
-@@ -38,7 +40,13 @@ def main() -> None:
-     connection = Redis.from_url(settings.redis_url)
-     worker = Worker([settings.rq_queue_name], connection=connection)
-     _install_signal_handlers(worker)
--    worker.work(with_scheduler=False, burst=settings.rq_worker_burst)
-+    try:
-+        worker.work(with_scheduler=False, burst=settings.rq_worker_burst)
-+    finally:
-+        try:
-+            asyncio.run(LLMClient.close())
-+        except Exception:
-+            _logger.warning("Failed to close shared LLM HTTP client", exc_info=True)
- 
- 
- if __name__ == "__main__":
 diff --git a/lan_transcriber/llm_client.py b/lan_transcriber/llm_client.py
-index 4203a29..f295a57 100644
+index f295a57..5129b2b 100644
 --- a/lan_transcriber/llm_client.py
 +++ b/lan_transcriber/llm_client.py
-@@ -217,6 +217,9 @@ class LLMTruncatedResponseError(ValueError):
- class LLMClient:
-     """Simple asynchronous client for the language model API."""
+@@ -219,6 +219,7 @@ class LLMClient:
  
-+    _http_client: httpx.AsyncClient | None = None
-+    _http_client_factory: Any = None
-+
+     _http_client: httpx.AsyncClient | None = None
+     _http_client_factory: Any = None
++    _http_client_timeout: float | None = None
+ 
      def __init__(
          self,
-         base_url: str | None = None,
-@@ -251,6 +254,34 @@ class LLMClient:
+@@ -254,21 +255,28 @@ class LLMClient:
          configured_mock_path = mock_response_path or os.getenv("LLM_MOCK_RESPONSE_PATH")
          self.mock_response_path = Path(configured_mock_path) if configured_mock_path else None
  
-+    @classmethod
-+    def _get_client(cls) -> httpx.AsyncClient:
-+        current_factory = httpx.AsyncClient
-+        client = cls._http_client
-+        client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
-+        if (
-+            client is None
-+            or client_closed
-+            or cls._http_client_factory is not current_factory
-+        ):
-+            cls._http_client = current_factory(
-+                timeout=httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0),
-+                limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
-+            )
-+            cls._http_client_factory = current_factory
-+        return cls._http_client
-+
-+    @classmethod
-+    async def close(cls) -> None:
-+        client = cls._http_client
-+        cls._http_client = None
-+        cls._http_client_factory = None
-+        if client is None or bool(getattr(client, "is_closed", False)):
-+            return
-+        aclose = getattr(client, "aclose", None)
-+        if callable(aclose):
-+            await aclose()
-+
-     @retry(
-         wait=wait_exponential(multiplier=1, min=1, max=8),
-         stop=stop_after_attempt(3),
-@@ -274,30 +305,30 @@ class LLMClient:
+-    @classmethod
+-    def _get_client(cls) -> httpx.AsyncClient:
++    async def _get_client(self) -> httpx.AsyncClient:
++        cls = type(self)
+         current_factory = httpx.AsyncClient
+         client = cls._http_client
+         client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
++        timeout_changed = cls._http_client_timeout != self.timeout
+         if (
+             client is None
+             or client_closed
+             or cls._http_client_factory is not current_factory
++            or timeout_changed
+         ):
++            if client is not None and not client_closed:
++                aclose = getattr(client, "aclose", None)
++                if callable(aclose):
++                    await aclose()
+             cls._http_client = current_factory(
+-                timeout=httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0),
++                timeout=httpx.Timeout(self.timeout),
+                 limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
+             )
+             cls._http_client_factory = current_factory
++            cls._http_client_timeout = self.timeout
+         return cls._http_client
+ 
+     @classmethod
+@@ -276,6 +284,7 @@ class LLMClient:
+         client = cls._http_client
+         cls._http_client = None
+         cls._http_client_factory = None
++        cls._http_client_timeout = None
+         if client is None or bool(getattr(client, "is_closed", False)):
+             return
+         aclose = getattr(client, "aclose", None)
+@@ -305,7 +314,7 @@ class LLMClient:
              attempt_number if attempt_number is not None else "unknown",
              payload.get("response_format") is not None,
          )
--        async with httpx.AsyncClient(timeout=self.timeout) as client:
--            with anyio.fail_after(self.timeout):
--                resp = await client.post(url, json=payload, headers=headers)
--            try:
--                resp.raise_for_status()
--            except httpx.HTTPStatusError as exc:
--                model_label = str(payload.get("model") or "<unset>")
--                message = (
--                    "LLM HTTP request failed "
--                    f"status_code={resp.status_code} "
--                    f"llm_url={url} "
--                    f"model={model_label} "
--                    f"max_tokens={payload.get('max_tokens')} "
--                    f"body={_error_body_snippet(resp)}"
--                )
--                raise httpx.HTTPStatusError(
--                    message,
--                    request=exc.request,
--                    response=exc.response,
--                ) from exc
--            data = resp.json()
--            if not isinstance(data, dict):
--                raise ValueError("LLM response must be a JSON object")
--            return data
-+        client = self._get_client()
-+        with anyio.fail_after(self.timeout):
-+            resp = await client.post(url, json=payload, headers=headers)
-+        try:
-+            resp.raise_for_status()
-+        except httpx.HTTPStatusError as exc:
-+            model_label = str(payload.get("model") or "<unset>")
-+            message = (
-+                "LLM HTTP request failed "
-+                f"status_code={resp.status_code} "
-+                f"llm_url={url} "
-+                f"model={model_label} "
-+                f"max_tokens={payload.get('max_tokens')} "
-+                f"body={_error_body_snippet(resp)}"
-+            )
-+            raise httpx.HTTPStatusError(
-+                message,
-+                request=exc.request,
-+                response=exc.response,
-+            ) from exc
-+        data = resp.json()
-+        if not isinstance(data, dict):
-+            raise ValueError("LLM response must be a JSON object")
-+        return data
- 
-     def _load_mock_message(self) -> Dict[str, str] | None:
-         if self.mock_response_path is None:
-diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
-index 1281851..ce97c37 100644
---- a/tasks/QUEUE.md
-+++ b/tasks/QUEUE.md
-@@ -761,7 +761,7 @@ Queue (in order)
- - Depends on: PR-NOISE-SPEAKER-FILTER-01
- 
- 152) PR-LLM-CLIENT-POOLING-01: Reuse httpx.AsyncClient across LLM requests with connection pooling
--- Status: TODO
-+- Status: DOING
- - Tasks file: tasks/PR-LLM-CLIENT-POOLING-01.md
- - Depends on: PR-LLM-INLINE-EXECUTION-01
- 
+-        client = self._get_client()
++        client = await self._get_client()
+         with anyio.fail_after(self.timeout):
+             resp = await client.post(url, json=payload, headers=headers)
+         try:
 diff --git a/tests/test_llm_client.py b/tests/test_llm_client.py
-index 842e2aa..2187cfd 100644
+index 2187cfd..103fb27 100644
 --- a/tests/test_llm_client.py
 +++ b/tests/test_llm_client.py
-@@ -97,6 +97,88 @@ async def test_generate_payload_includes_max_tokens() -> None:
-     assert payload["max_tokens"] == 1536
+@@ -152,10 +152,15 @@ async def test_post_chat_completion_reuses_shared_http_client(
+     assert len(created_clients) == 1
+     assert created_clients[0].calls[0][1]["max_tokens"] == 111
+     assert created_clients[0].calls[1][1]["max_tokens"] == 222
++    timeout = created_clients[0].kwargs["timeout"]
++    assert timeout.connect == pytest.approx(0.1)
++    assert timeout.read == pytest.approx(0.1)
++    assert timeout.write == pytest.approx(0.1)
++    assert timeout.pool == pytest.approx(0.1)
  
+     await llm_client.LLMClient.close()
+     assert created_clients[0].is_closed is True
+-    replacement = client._get_client()
++    replacement = await client._get_client()
+     assert len(created_clients) == 2
+     assert replacement is created_clients[1]
+     assert created_clients[1].kwargs["limits"] == httpx.Limits(
+@@ -172,11 +177,62 @@ async def test_close_tolerates_client_without_async_close() -> None:
  
+     llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
+     llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
++    llm_client.LLMClient._http_client_timeout = 5.0  # noqa: SLF001
+ 
+     await llm_client.LLMClient.close()
+ 
+     assert llm_client.LLMClient._http_client is None  # noqa: SLF001
+     assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
++    assert llm_client.LLMClient._http_client_timeout is None  # noqa: SLF001
++
++
 +@pytest.mark.asyncio
-+async def test_post_chat_completion_reuses_shared_http_client(
++async def test_post_chat_completion_recreates_shared_client_when_timeout_changes(
 +    monkeypatch: pytest.MonkeyPatch,
 +) -> None:
 +    created_clients: list["_FakeClient"] = []
@@ -176,17 +112,9 @@ index 842e2aa..2187cfd 100644
 +        def __init__(self, **kwargs: Any) -> None:
 +            self.kwargs = kwargs
 +            self.is_closed = False
-+            self.calls: list[tuple[str, dict[str, Any], dict[str, str]]] = []
 +            created_clients.append(self)
 +
-+        async def post(
-+            self,
-+            url: str,
-+            *,
-+            json: dict[str, Any],
-+            headers: dict[str, str],
-+        ) -> _FakeResponse:
-+            self.calls.append((url, json, headers))
++        async def post(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
 +            return _FakeResponse()
 +
 +        async def aclose(self) -> None:
@@ -194,173 +122,42 @@ index 842e2aa..2187cfd 100644
 +
 +    await llm_client.LLMClient.close()
 +    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
-+    client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
++    fast_client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
++    slow_client = llm_client.LLMClient(base_url="http://example.test", timeout=321.0)
 +
-+    first = await client._post_chat_completion(
++    await fast_client._post_chat_completion(
 +        url="http://example.test/v1/chat/completions",
 +        payload={"messages": [], "max_tokens": 111},
-+        headers={"Authorization": "Bearer secret"},
++        headers={},
 +    )
-+    second = await client._post_chat_completion(
++    await slow_client._post_chat_completion(
 +        url="http://example.test/v1/chat/completions",
 +        payload={"messages": [], "max_tokens": 222},
 +        headers={},
 +    )
 +
-+    assert first["choices"][0]["message"]["content"] == "ok"
-+    assert second["choices"][0]["message"]["content"] == "ok"
-+    assert len(created_clients) == 1
-+    assert created_clients[0].calls[0][1]["max_tokens"] == 111
-+    assert created_clients[0].calls[1][1]["max_tokens"] == 222
-+
-+    await llm_client.LLMClient.close()
-+    assert created_clients[0].is_closed is True
-+    replacement = client._get_client()
 +    assert len(created_clients) == 2
-+    assert replacement is created_clients[1]
-+    assert created_clients[1].kwargs["limits"] == httpx.Limits(
-+        max_connections=5,
-+        max_keepalive_connections=2,
-+    )
++    assert created_clients[0].is_closed is True
++    assert created_clients[1].kwargs["timeout"].read == pytest.approx(321.0)
 +    await llm_client.LLMClient.close()
-+
-+
-+@pytest.mark.asyncio
-+async def test_close_tolerates_client_without_async_close() -> None:
-+    class _ClientWithoutClose:
-+        is_closed = False
-+
-+    llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
-+    llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
-+
-+    await llm_client.LLMClient.close()
-+
-+    assert llm_client.LLMClient._http_client is None  # noqa: SLF001
-+    assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
-+
-+
+ 
+ 
  @pytest.mark.asyncio
- @respx.mock
- async def test_generate_omits_model_when_not_configured() -> None:
-@@ -663,3 +745,121 @@ async def test_generate_debug_log_uses_safe_request_metadata(caplog: pytest.LogC
-     assert "response_format=True" in debug_messages
-     assert "system-super-secret" not in debug_messages
-     assert "user-ultra-secret" not in debug_messages
-+
-+
-+def test_worker_main_closes_shared_http_client_on_shutdown(
-+    monkeypatch: pytest.MonkeyPatch,
-+) -> None:
-+    import importlib
-+    import types
-+
-+    monkeypatch.setitem(sys.modules, "redis", types.SimpleNamespace(Redis=type("Redis", (), {})))
-+    monkeypatch.setitem(sys.modules, "rq", types.SimpleNamespace(Worker=type("Worker", (), {})))
-+    worker_module = importlib.import_module("lan_app.worker")
-+
-+    calls: dict[str, object] = {}
-+    settings = type(
-+        "Settings",
-+        (),
-+        {
-+            "redis_url": "redis://unit",
-+            "rq_queue_name": "audio",
-+            "rq_worker_burst": False,
-+            "data_root": pathlib.Path("/tmp/worker-llm-close"),
-+        },
-+    )()
-+
-+    monkeypatch.setattr(worker_module, "AppSettings", lambda: settings)
-+    monkeypatch.setattr(worker_module, "init_db", lambda cfg: calls.setdefault("init_db", cfg))
-+    monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
-+    monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
-+    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
-+    monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
-+
-+    class _FakeWorker:
-+        def __init__(self, queues, *, connection):
-+            calls["queues"] = queues
-+            calls["connection"] = connection
-+
-+        def work(self, *, with_scheduler, burst):
-+            calls["work"] = (with_scheduler, burst)
-+            raise RuntimeError("boom")
-+
-+    async def _fake_close(_cls) -> None:
-+        calls["close_count"] = int(calls.get("close_count", 0)) + 1
-+
-+    original_asyncio_run = asyncio.run
-+
-+    def _run_coroutine(coro):
-+        calls["asyncio_run_called"] = True
-+        return original_asyncio_run(coro)
-+
-+    monkeypatch.setattr(worker_module, "Worker", _FakeWorker)
-+    monkeypatch.setattr(worker_module.asyncio, "run", _run_coroutine)
-+    monkeypatch.setattr(worker_module.LLMClient, "close", classmethod(_fake_close))
-+
-+    with pytest.raises(RuntimeError, match="boom"):
-+        worker_module.main()
-+
-+    assert calls["init_db"] is settings
-+    assert calls["queues"] == ["audio"]
-+    assert calls["work"] == (False, False)
-+    assert calls["asyncio_run_called"] is True
-+    assert calls["close_count"] == 1
-+
-+
-+def test_worker_main_logs_close_failure_without_masking_worker_error(
-+    monkeypatch: pytest.MonkeyPatch,
-+) -> None:
-+    import importlib
-+    import types
-+
-+    monkeypatch.setitem(sys.modules, "redis", types.SimpleNamespace(Redis=type("Redis", (), {})))
-+    monkeypatch.setitem(sys.modules, "rq", types.SimpleNamespace(Worker=type("Worker", (), {})))
-+    worker_module = importlib.import_module("lan_app.worker")
-+
-+    calls: dict[str, object] = {}
-+    settings = type(
-+        "Settings",
-+        (),
-+        {
-+            "redis_url": "redis://unit",
-+            "rq_queue_name": "audio",
-+            "rq_worker_burst": False,
-+            "data_root": pathlib.Path("/tmp/worker-llm-close-warning"),
-+        },
-+    )()
-+
-+    monkeypatch.setattr(worker_module, "AppSettings", lambda: settings)
-+    monkeypatch.setattr(worker_module, "init_db", lambda *_args: None)
-+    monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
-+    monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
-+    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
-+    monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
-+    monkeypatch.setattr(
-+        worker_module._logger,
-+        "warning",
-+        lambda message, **kwargs: calls.update({"warning": message, "warning_kwargs": kwargs}),
-+    )
-+
-+    class _FakeWorker:
-+        def __init__(self, queues, *, connection):
-+            calls["queues"] = queues
-+            calls["connection"] = connection
-+
-+        def work(self, *, with_scheduler, burst):
-+            calls["work"] = (with_scheduler, burst)
-+            raise RuntimeError("worker-boom")
-+
-+    def _run_coroutine(coro):
-+        coro.close()
-+        raise RuntimeError("close-boom")
-+
-+    monkeypatch.setattr(worker_module, "Worker", _FakeWorker)
-+    monkeypatch.setattr(worker_module.asyncio, "run", _run_coroutine)
-+
-+    with pytest.raises(RuntimeError, match="worker-boom"):
-+        worker_module.main()
-+
-+    assert calls["warning"] == "Failed to close shared LLM HTTP client"
-+    assert calls["warning_kwargs"] == {"exc_info": True}
+@@ -773,7 +829,7 @@ def test_worker_main_closes_shared_http_client_on_shutdown(
+     monkeypatch.setattr(worker_module, "init_db", lambda cfg: calls.setdefault("init_db", cfg))
+     monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
+     monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
+-    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
++    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object(), raising=False)
+     monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
+ 
+     class _FakeWorker:
+@@ -834,7 +890,7 @@ def test_worker_main_logs_close_failure_without_masking_worker_error(
+     monkeypatch.setattr(worker_module, "init_db", lambda *_args: None)
+     monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
+     monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
+-    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
++    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object(), raising=False)
+     monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
+     monkeypatch.setattr(
+         worker_module._logger,

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,153 +1,366 @@
-diff --git a/lan_app/worker_tasks.py b/lan_app/worker_tasks.py
-index 470e5a4..17b9d48 100644
---- a/lan_app/worker_tasks.py
-+++ b/lan_app/worker_tasks.py
-@@ -573,6 +573,7 @@ def _rehydrate_child_operation_error(
-             "ReadError",
-             "RemoteProtocolError",
-             "ConnectionError",
-+            "RequestError",
-         }:
-             return ConnectionError(message)
-         if error_type in {
-@@ -583,7 +584,11 @@ def _rehydrate_child_operation_error(
-             "TimeoutException",
-         }:
-             return TimeoutError(message)
--        if error_type in {"LLMEmptyContentError", "LLMTruncatedResponseError"}:
-+        if error_type in {
-+            "LLMEmptyContentError",
-+            "LLMTruncatedResponseError",
-+            "HTTPStatusError",
-+        }:
-             return RuntimeError(message)
-     builtins_ns = __builtins__ if isinstance(__builtins__, dict) else vars(__builtins__)
-     builtin_exc = builtins_ns.get(error_type)
-@@ -996,8 +1001,14 @@ class _CancelAwareLLMClient:
-         except asyncio.CancelledError:
-             await self._cancel_request_task(request_task)
-             raise
--        except BaseException:
-+        except BaseException as exc:
-             await self._cancel_request_task(request_task)
-+            if isinstance(exc, Exception):
-+                raise _rehydrate_child_operation_error(
-+                    operation_name="llm_generate",
-+                    error_type=type(exc).__name__,
-+                    error_message=str(exc) or type(exc).__name__,
-+                ) from exc
-             raise
+diff --git a/lan_app/worker.py b/lan_app/worker.py
+index 0595d06..2f032da 100644
+--- a/lan_app/worker.py
++++ b/lan_app/worker.py
+@@ -1,5 +1,6 @@
+ from __future__ import annotations
  
-     def generate(self, *args: Any, **kwargs: Any) -> Any:
-diff --git a/tests/test_cov_lan_app_worker_tasks_branches.py b/tests/test_cov_lan_app_worker_tasks_branches.py
-index 1999f77..ed31eae 100644
---- a/tests/test_cov_lan_app_worker_tasks_branches.py
-+++ b/tests/test_cov_lan_app_worker_tasks_branches.py
-@@ -2,6 +2,7 @@ from __future__ import annotations
++import asyncio
+ import logging
+ import signal
+ from types import FrameType
+@@ -9,6 +10,7 @@ from rq import Worker
  
- import asyncio
- import builtins
-+import httpx
- import json
- from pathlib import Path
- import sqlite3
-@@ -1617,6 +1618,99 @@ def test_cancel_aware_llm_client_inline_runtime_error_propagates(tmp_path: Path)
+ from .config import AppSettings
+ from .db import init_db
++from lan_transcriber.llm_client import LLMClient
+ from .worker_status import start_heartbeat_thread, write_worker_status
+ 
+ _logger = logging.getLogger(__name__)
+@@ -38,7 +40,13 @@ def main() -> None:
+     connection = Redis.from_url(settings.redis_url)
+     worker = Worker([settings.rq_queue_name], connection=connection)
+     _install_signal_handlers(worker)
+-    worker.work(with_scheduler=False, burst=settings.rq_worker_burst)
++    try:
++        worker.work(with_scheduler=False, burst=settings.rq_worker_burst)
++    finally:
++        try:
++            asyncio.run(LLMClient.close())
++        except Exception:
++            _logger.warning("Failed to close shared LLM HTTP client", exc_info=True)
+ 
+ 
+ if __name__ == "__main__":
+diff --git a/lan_transcriber/llm_client.py b/lan_transcriber/llm_client.py
+index 4203a29..f295a57 100644
+--- a/lan_transcriber/llm_client.py
++++ b/lan_transcriber/llm_client.py
+@@ -217,6 +217,9 @@ class LLMTruncatedResponseError(ValueError):
+ class LLMClient:
+     """Simple asynchronous client for the language model API."""
+ 
++    _http_client: httpx.AsyncClient | None = None
++    _http_client_factory: Any = None
++
+     def __init__(
+         self,
+         base_url: str | None = None,
+@@ -251,6 +254,34 @@ class LLMClient:
+         configured_mock_path = mock_response_path or os.getenv("LLM_MOCK_RESPONSE_PATH")
+         self.mock_response_path = Path(configured_mock_path) if configured_mock_path else None
+ 
++    @classmethod
++    def _get_client(cls) -> httpx.AsyncClient:
++        current_factory = httpx.AsyncClient
++        client = cls._http_client
++        client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
++        if (
++            client is None
++            or client_closed
++            or cls._http_client_factory is not current_factory
++        ):
++            cls._http_client = current_factory(
++                timeout=httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0),
++                limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
++            )
++            cls._http_client_factory = current_factory
++        return cls._http_client
++
++    @classmethod
++    async def close(cls) -> None:
++        client = cls._http_client
++        cls._http_client = None
++        cls._http_client_factory = None
++        if client is None or bool(getattr(client, "is_closed", False)):
++            return
++        aclose = getattr(client, "aclose", None)
++        if callable(aclose):
++            await aclose()
++
+     @retry(
+         wait=wait_exponential(multiplier=1, min=1, max=8),
+         stop=stop_after_attempt(3),
+@@ -274,30 +305,30 @@ class LLMClient:
+             attempt_number if attempt_number is not None else "unknown",
+             payload.get("response_format") is not None,
          )
+-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+-            with anyio.fail_after(self.timeout):
+-                resp = await client.post(url, json=payload, headers=headers)
+-            try:
+-                resp.raise_for_status()
+-            except httpx.HTTPStatusError as exc:
+-                model_label = str(payload.get("model") or "<unset>")
+-                message = (
+-                    "LLM HTTP request failed "
+-                    f"status_code={resp.status_code} "
+-                    f"llm_url={url} "
+-                    f"model={model_label} "
+-                    f"max_tokens={payload.get('max_tokens')} "
+-                    f"body={_error_body_snippet(resp)}"
+-                )
+-                raise httpx.HTTPStatusError(
+-                    message,
+-                    request=exc.request,
+-                    response=exc.response,
+-                ) from exc
+-            data = resp.json()
+-            if not isinstance(data, dict):
+-                raise ValueError("LLM response must be a JSON object")
+-            return data
++        client = self._get_client()
++        with anyio.fail_after(self.timeout):
++            resp = await client.post(url, json=payload, headers=headers)
++        try:
++            resp.raise_for_status()
++        except httpx.HTTPStatusError as exc:
++            model_label = str(payload.get("model") or "<unset>")
++            message = (
++                "LLM HTTP request failed "
++                f"status_code={resp.status_code} "
++                f"llm_url={url} "
++                f"model={model_label} "
++                f"max_tokens={payload.get('max_tokens')} "
++                f"body={_error_body_snippet(resp)}"
++            )
++            raise httpx.HTTPStatusError(
++                message,
++                request=exc.request,
++                response=exc.response,
++            ) from exc
++        data = resp.json()
++        if not isinstance(data, dict):
++            raise ValueError("LLM response must be a JSON object")
++        return data
+ 
+     def _load_mock_message(self) -> Dict[str, str] | None:
+         if self.mock_response_path is None:
+diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
+index 1281851..ce97c37 100644
+--- a/tasks/QUEUE.md
++++ b/tasks/QUEUE.md
+@@ -761,7 +761,7 @@ Queue (in order)
+ - Depends on: PR-NOISE-SPEAKER-FILTER-01
+ 
+ 152) PR-LLM-CLIENT-POOLING-01: Reuse httpx.AsyncClient across LLM requests with connection pooling
+-- Status: TODO
++- Status: DOING
+ - Tasks file: tasks/PR-LLM-CLIENT-POOLING-01.md
+ - Depends on: PR-LLM-INLINE-EXECUTION-01
+ 
+diff --git a/tests/test_llm_client.py b/tests/test_llm_client.py
+index 842e2aa..2187cfd 100644
+--- a/tests/test_llm_client.py
++++ b/tests/test_llm_client.py
+@@ -97,6 +97,88 @@ async def test_generate_payload_includes_max_tokens() -> None:
+     assert payload["max_tokens"] == 1536
  
  
-+def test_cancel_aware_llm_client_normalizes_inline_connect_error(tmp_path: Path) -> None:
-+    cfg = _db_settings(tmp_path)
-+    init_db(cfg)
-+    create_recording(
-+        "rec-stop-inline-llm-7",
-+        source="test",
-+        source_filename="llm-connect.wav",
-+        settings=cfg,
++@pytest.mark.asyncio
++async def test_post_chat_completion_reuses_shared_http_client(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    created_clients: list["_FakeClient"] = []
++
++    class _FakeResponse:
++        status_code = 200
++
++        def raise_for_status(self) -> None:
++            return None
++
++        def json(self) -> dict[str, object]:
++            return {"choices": [{"message": {"content": "ok"}}]}
++
++    class _FakeClient:
++        def __init__(self, **kwargs: Any) -> None:
++            self.kwargs = kwargs
++            self.is_closed = False
++            self.calls: list[tuple[str, dict[str, Any], dict[str, str]]] = []
++            created_clients.append(self)
++
++        async def post(
++            self,
++            url: str,
++            *,
++            json: dict[str, Any],
++            headers: dict[str, str],
++        ) -> _FakeResponse:
++            self.calls.append((url, json, headers))
++            return _FakeResponse()
++
++        async def aclose(self) -> None:
++            self.is_closed = True
++
++    await llm_client.LLMClient.close()
++    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
++    client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
++
++    first = await client._post_chat_completion(
++        url="http://example.test/v1/chat/completions",
++        payload={"messages": [], "max_tokens": 111},
++        headers={"Authorization": "Bearer secret"},
++    )
++    second = await client._post_chat_completion(
++        url="http://example.test/v1/chat/completions",
++        payload={"messages": [], "max_tokens": 222},
++        headers={},
 +    )
 +
-+    class _ConnectErrorClient:
-+        async def generate(self, *_args, **_kwargs):
-+            request = httpx.Request("POST", "http://127.0.0.1:8000/v1/chat/completions")
-+            raise httpx.ConnectError("connect boom", request=request)
++    assert first["choices"][0]["message"]["content"] == "ok"
++    assert second["choices"][0]["message"]["content"] == "ok"
++    assert len(created_clients) == 1
++    assert created_clients[0].calls[0][1]["max_tokens"] == 111
++    assert created_clients[0].calls[1][1]["max_tokens"] == 222
 +
-+    llm_client = worker_tasks._CancelAwareLLMClient(  # noqa: SLF001
-+        base_client=_ConnectErrorClient(),
-+        recording_id="rec-stop-inline-llm-7",
-+        settings=cfg,
-+        stage_name="llm_extract",
-+        log_path=tmp_path / "logs" / "llm-connect.log",
++    await llm_client.LLMClient.close()
++    assert created_clients[0].is_closed is True
++    replacement = client._get_client()
++    assert len(created_clients) == 2
++    assert replacement is created_clients[1]
++    assert created_clients[1].kwargs["limits"] == httpx.Limits(
++        max_connections=5,
++        max_keepalive_connections=2,
++    )
++    await llm_client.LLMClient.close()
++
++
++@pytest.mark.asyncio
++async def test_close_tolerates_client_without_async_close() -> None:
++    class _ClientWithoutClose:
++        is_closed = False
++
++    llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
++    llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
++
++    await llm_client.LLMClient.close()
++
++    assert llm_client.LLMClient._http_client is None  # noqa: SLF001
++    assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
++
++
+ @pytest.mark.asyncio
+ @respx.mock
+ async def test_generate_omits_model_when_not_configured() -> None:
+@@ -663,3 +745,121 @@ async def test_generate_debug_log_uses_safe_request_metadata(caplog: pytest.LogC
+     assert "response_format=True" in debug_messages
+     assert "system-super-secret" not in debug_messages
+     assert "user-ultra-secret" not in debug_messages
++
++
++def test_worker_main_closes_shared_http_client_on_shutdown(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    import importlib
++    import types
++
++    monkeypatch.setitem(sys.modules, "redis", types.SimpleNamespace(Redis=type("Redis", (), {})))
++    monkeypatch.setitem(sys.modules, "rq", types.SimpleNamespace(Worker=type("Worker", (), {})))
++    worker_module = importlib.import_module("lan_app.worker")
++
++    calls: dict[str, object] = {}
++    settings = type(
++        "Settings",
++        (),
++        {
++            "redis_url": "redis://unit",
++            "rq_queue_name": "audio",
++            "rq_worker_burst": False,
++            "data_root": pathlib.Path("/tmp/worker-llm-close"),
++        },
++    )()
++
++    monkeypatch.setattr(worker_module, "AppSettings", lambda: settings)
++    monkeypatch.setattr(worker_module, "init_db", lambda cfg: calls.setdefault("init_db", cfg))
++    monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
++    monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
++    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
++    monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
++
++    class _FakeWorker:
++        def __init__(self, queues, *, connection):
++            calls["queues"] = queues
++            calls["connection"] = connection
++
++        def work(self, *, with_scheduler, burst):
++            calls["work"] = (with_scheduler, burst)
++            raise RuntimeError("boom")
++
++    async def _fake_close(_cls) -> None:
++        calls["close_count"] = int(calls.get("close_count", 0)) + 1
++
++    original_asyncio_run = asyncio.run
++
++    def _run_coroutine(coro):
++        calls["asyncio_run_called"] = True
++        return original_asyncio_run(coro)
++
++    monkeypatch.setattr(worker_module, "Worker", _FakeWorker)
++    monkeypatch.setattr(worker_module.asyncio, "run", _run_coroutine)
++    monkeypatch.setattr(worker_module.LLMClient, "close", classmethod(_fake_close))
++
++    with pytest.raises(RuntimeError, match="boom"):
++        worker_module.main()
++
++    assert calls["init_db"] is settings
++    assert calls["queues"] == ["audio"]
++    assert calls["work"] == (False, False)
++    assert calls["asyncio_run_called"] is True
++    assert calls["close_count"] == 1
++
++
++def test_worker_main_logs_close_failure_without_masking_worker_error(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    import importlib
++    import types
++
++    monkeypatch.setitem(sys.modules, "redis", types.SimpleNamespace(Redis=type("Redis", (), {})))
++    monkeypatch.setitem(sys.modules, "rq", types.SimpleNamespace(Worker=type("Worker", (), {})))
++    worker_module = importlib.import_module("lan_app.worker")
++
++    calls: dict[str, object] = {}
++    settings = type(
++        "Settings",
++        (),
++        {
++            "redis_url": "redis://unit",
++            "rq_queue_name": "audio",
++            "rq_worker_burst": False,
++            "data_root": pathlib.Path("/tmp/worker-llm-close-warning"),
++        },
++    )()
++
++    monkeypatch.setattr(worker_module, "AppSettings", lambda: settings)
++    monkeypatch.setattr(worker_module, "init_db", lambda *_args: None)
++    monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
++    monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
++    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
++    monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
++    monkeypatch.setattr(
++        worker_module._logger,
++        "warning",
++        lambda message, **kwargs: calls.update({"warning": message, "warning_kwargs": kwargs}),
 +    )
 +
-+    with pytest.raises(ConnectionError, match="connect boom"):
-+        asyncio.run(
-+            llm_client.generate(
-+                system_prompt="sys",
-+                user_prompt="user",
-+            )
-+        )
++    class _FakeWorker:
++        def __init__(self, queues, *, connection):
++            calls["queues"] = queues
++            calls["connection"] = connection
 +
++        def work(self, *, with_scheduler, burst):
++            calls["work"] = (with_scheduler, burst)
++            raise RuntimeError("worker-boom")
 +
-+def test_cancel_aware_llm_client_normalizes_inline_http_status_error(tmp_path: Path) -> None:
-+    cfg = _db_settings(tmp_path)
-+    init_db(cfg)
-+    create_recording(
-+        "rec-stop-inline-llm-8",
-+        source="test",
-+        source_filename="llm-status.wav",
-+        settings=cfg,
-+    )
++    def _run_coroutine(coro):
++        coro.close()
++        raise RuntimeError("close-boom")
 +
-+    class _HttpStatusErrorClient:
-+        async def generate(self, *_args, **_kwargs):
-+            request = httpx.Request("POST", "http://127.0.0.1:8000/v1/chat/completions")
-+            response = httpx.Response(502, request=request)
-+            raise httpx.HTTPStatusError("bad gateway", request=request, response=response)
++    monkeypatch.setattr(worker_module, "Worker", _FakeWorker)
++    monkeypatch.setattr(worker_module.asyncio, "run", _run_coroutine)
 +
-+    llm_client = worker_tasks._CancelAwareLLMClient(  # noqa: SLF001
-+        base_client=_HttpStatusErrorClient(),
-+        recording_id="rec-stop-inline-llm-8",
-+        settings=cfg,
-+        stage_name="llm_extract",
-+        log_path=tmp_path / "logs" / "llm-status.log",
-+    )
++    with pytest.raises(RuntimeError, match="worker-boom"):
++        worker_module.main()
 +
-+    with pytest.raises(RuntimeError, match="bad gateway"):
-+        asyncio.run(
-+            llm_client.generate(
-+                system_prompt="sys",
-+                user_prompt="user",
-+            )
-+        )
-+
-+
-+def test_cancel_aware_llm_client_reraises_inline_baseexception(tmp_path: Path) -> None:
-+    cfg = _db_settings(tmp_path)
-+    init_db(cfg)
-+    create_recording(
-+        "rec-stop-inline-llm-9",
-+        source="test",
-+        source_filename="llm-baseexception.wav",
-+        settings=cfg,
-+    )
-+
-+    class _SentinelBaseException(BaseException):
-+        pass
-+
-+    async def _raise_baseexception():
-+        raise _SentinelBaseException("sentinel")
-+
-+    llm_client = worker_tasks._CancelAwareLLMClient(  # noqa: SLF001
-+        base_client=object(),
-+        recording_id="rec-stop-inline-llm-9",
-+        settings=cfg,
-+        stage_name="llm_extract",
-+        log_path=tmp_path / "logs" / "llm-baseexception.log",
-+    )
-+
-+    with pytest.raises(_SentinelBaseException, match="sentinel"):
-+        asyncio.run(llm_client._await_inline_generate(_raise_baseexception()))  # noqa: SLF001
-+
-+
- def test_execute_diarization_workflow_direct_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-     cfg = worker_tasks._build_pipeline_settings(_db_settings(tmp_path))  # noqa: SLF001
-     annotation = object()
++    assert calls["warning"] == "Failed to close shared LLM HTTP client"
++    assert calls["warning_kwargs"] == {"exc_info": True}

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,103 +1,207 @@
 diff --git a/lan_transcriber/llm_client.py b/lan_transcriber/llm_client.py
-index f295a57..5129b2b 100644
+index 5129b2b..abf954d 100644
 --- a/lan_transcriber/llm_client.py
 +++ b/lan_transcriber/llm_client.py
-@@ -219,6 +219,7 @@ class LLMClient:
+@@ -2,11 +2,13 @@
  
-     _http_client: httpx.AsyncClient | None = None
-     _http_client_factory: Any = None
-+    _http_client_timeout: float | None = None
+ from __future__ import annotations
+ 
++import asyncio
+ import json
+ import logging
+ import os
+ from pathlib import Path
+ from typing import Any, Dict, List, Optional
++import weakref
+ 
+ import anyio
+ import httpx
+@@ -217,9 +219,9 @@ class LLMTruncatedResponseError(ValueError):
+ class LLMClient:
+     """Simple asynchronous client for the language model API."""
+ 
+-    _http_client: httpx.AsyncClient | None = None
+-    _http_client_factory: Any = None
+-    _http_client_timeout: float | None = None
++    _http_clients: weakref.WeakKeyDictionary[
++        asyncio.AbstractEventLoop, dict[tuple[Any, float], httpx.AsyncClient]
++    ] = weakref.WeakKeyDictionary()
  
      def __init__(
          self,
-@@ -254,21 +255,28 @@ class LLMClient:
-         configured_mock_path = mock_response_path or os.getenv("LLM_MOCK_RESPONSE_PATH")
-         self.mock_response_path = Path(configured_mock_path) if configured_mock_path else None
- 
--    @classmethod
--    def _get_client(cls) -> httpx.AsyncClient:
-+    async def _get_client(self) -> httpx.AsyncClient:
-+        cls = type(self)
+@@ -258,38 +260,34 @@ class LLMClient:
+     async def _get_client(self) -> httpx.AsyncClient:
+         cls = type(self)
          current_factory = httpx.AsyncClient
-         client = cls._http_client
-         client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
-+        timeout_changed = cls._http_client_timeout != self.timeout
-         if (
-             client is None
-             or client_closed
-             or cls._http_client_factory is not current_factory
-+            or timeout_changed
-         ):
-+            if client is not None and not client_closed:
+-        client = cls._http_client
+-        client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
+-        timeout_changed = cls._http_client_timeout != self.timeout
+-        if (
+-            client is None
+-            or client_closed
+-            or cls._http_client_factory is not current_factory
+-            or timeout_changed
+-        ):
+-            if client is not None and not client_closed:
+-                aclose = getattr(client, "aclose", None)
+-                if callable(aclose):
+-                    await aclose()
+-            cls._http_client = current_factory(
++        loop = asyncio.get_running_loop()
++        loop_clients = cls._http_clients.setdefault(loop, {})
++        client_key = (current_factory, self.timeout)
++        client = loop_clients.get(client_key)
++        if client is None or bool(getattr(client, "is_closed", False)):
++            client = current_factory(
+                 timeout=httpx.Timeout(self.timeout),
+                 limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
+             )
+-            cls._http_client_factory = current_factory
+-            cls._http_client_timeout = self.timeout
+-        return cls._http_client
++            loop_clients[client_key] = client
++        return client
+ 
+     @classmethod
+     async def close(cls) -> None:
+-        client = cls._http_client
+-        cls._http_client = None
+-        cls._http_client_factory = None
+-        cls._http_client_timeout = None
+-        if client is None or bool(getattr(client, "is_closed", False)):
+-            return
+-        aclose = getattr(client, "aclose", None)
+-        if callable(aclose):
+-            await aclose()
++        loop_clients = list(cls._http_clients.values())
++        cls._http_clients = weakref.WeakKeyDictionary()
++        closed_ids: set[int] = set()
++        for pool in loop_clients:
++            for client in pool.values():
++                client_id = id(client)
++                if client_id in closed_ids:
++                    continue
++                closed_ids.add(client_id)
++                if client is None or bool(getattr(client, "is_closed", False)):
++                    continue
 +                aclose = getattr(client, "aclose", None)
 +                if callable(aclose):
 +                    await aclose()
-             cls._http_client = current_factory(
--                timeout=httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0),
-+                timeout=httpx.Timeout(self.timeout),
-                 limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
-             )
-             cls._http_client_factory = current_factory
-+            cls._http_client_timeout = self.timeout
-         return cls._http_client
  
-     @classmethod
-@@ -276,6 +284,7 @@ class LLMClient:
-         client = cls._http_client
-         cls._http_client = None
-         cls._http_client_factory = None
-+        cls._http_client_timeout = None
-         if client is None or bool(getattr(client, "is_closed", False)):
-             return
-         aclose = getattr(client, "aclose", None)
-@@ -305,7 +314,7 @@ class LLMClient:
-             attempt_number if attempt_number is not None else "unknown",
-             payload.get("response_format") is not None,
-         )
--        client = self._get_client()
-+        client = await self._get_client()
-         with anyio.fail_after(self.timeout):
-             resp = await client.post(url, json=payload, headers=headers)
-         try:
+     @retry(
+         wait=wait_exponential(multiplier=1, min=1, max=8),
 diff --git a/tests/test_llm_client.py b/tests/test_llm_client.py
-index 2187cfd..103fb27 100644
+index 103fb27..6359dad 100644
 --- a/tests/test_llm_client.py
 +++ b/tests/test_llm_client.py
-@@ -152,10 +152,15 @@ async def test_post_chat_completion_reuses_shared_http_client(
-     assert len(created_clients) == 1
-     assert created_clients[0].calls[0][1]["max_tokens"] == 111
-     assert created_clients[0].calls[1][1]["max_tokens"] == 222
-+    timeout = created_clients[0].kwargs["timeout"]
-+    assert timeout.connect == pytest.approx(0.1)
-+    assert timeout.read == pytest.approx(0.1)
-+    assert timeout.write == pytest.approx(0.1)
-+    assert timeout.pool == pytest.approx(0.1)
+@@ -4,6 +4,7 @@ import logging
+ import pathlib
+ import sys
+ from typing import Any
++import weakref
  
-     await llm_client.LLMClient.close()
-     assert created_clients[0].is_closed is True
--    replacement = client._get_client()
-+    replacement = await client._get_client()
-     assert len(created_clients) == 2
-     assert replacement is created_clients[1]
-     assert created_clients[1].kwargs["limits"] == httpx.Limits(
-@@ -172,11 +177,62 @@ async def test_close_tolerates_client_without_async_close() -> None:
+ import httpx
+ import pytest
+@@ -175,22 +176,54 @@ async def test_close_tolerates_client_without_async_close() -> None:
+     class _ClientWithoutClose:
+         is_closed = False
  
-     llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
-     llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
-+    llm_client.LLMClient._http_client_timeout = 5.0  # noqa: SLF001
- 
-     await llm_client.LLMClient.close()
- 
-     assert llm_client.LLMClient._http_client is None  # noqa: SLF001
-     assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
-+    assert llm_client.LLMClient._http_client_timeout is None  # noqa: SLF001
+-    llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
+-    llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
+-    llm_client.LLMClient._http_client_timeout = 5.0  # noqa: SLF001
++    loop = asyncio.get_running_loop()
++    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
++        {loop: {("factory", 5.0): _ClientWithoutClose()}}
++    )
++
++    await llm_client.LLMClient.close()
++
++    assert len(llm_client.LLMClient._http_clients) == 0  # noqa: SLF001
 +
 +
 +@pytest.mark.asyncio
-+async def test_post_chat_completion_recreates_shared_client_when_timeout_changes(
++async def test_close_skips_duplicate_and_already_closed_clients() -> None:
++    loop = asyncio.get_running_loop()
++    close_calls: list[str] = []
++
++    class _TrackedClient:
++        def __init__(self, name: str, *, is_closed: bool) -> None:
++            self.name = name
++            self.is_closed = is_closed
++
++        async def aclose(self) -> None:
++            close_calls.append(self.name)
++            self.is_closed = True
++
++    shared = _TrackedClient("shared", is_closed=False)
++    closed = _TrackedClient("closed", is_closed=True)
++    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
++        {
++            loop: {
++                ("factory-a", 1.0): shared,
++                ("factory-b", 1.0): shared,
++                ("factory-c", 2.0): closed,
++            }
++        }
++    )
+ 
+     await llm_client.LLMClient.close()
+ 
+-    assert llm_client.LLMClient._http_client is None  # noqa: SLF001
+-    assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
+-    assert llm_client.LLMClient._http_client_timeout is None  # noqa: SLF001
++    assert close_calls == ["shared"]
++    assert len(llm_client.LLMClient._http_clients) == 0  # noqa: SLF001
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_post_chat_completion_recreates_shared_client_when_timeout_changes(
++async def test_post_chat_completion_uses_separate_clients_per_event_loop(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:
+     created_clients: list["_FakeClient"] = []
++    active_loop = None
+ 
+     class _FakeResponse:
+         status_code = 200
+@@ -215,6 +248,65 @@ async def test_post_chat_completion_recreates_shared_client_when_timeout_changes
+ 
+     await llm_client.LLMClient.close()
+     monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
++    loop_one = type("LoopToken", (), {})()
++    loop_two = type("LoopToken", (), {})()
++
++    def _get_running_loop():
++        return active_loop
++
++    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", _get_running_loop)
++    client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
++
++    active_loop = loop_one
++    await client._post_chat_completion(
++        url="http://example.test/v1/chat/completions",
++        payload={"messages": [], "max_tokens": 111},
++        headers={},
++    )
++    active_loop = loop_two
++    await client._post_chat_completion(
++        url="http://example.test/v1/chat/completions",
++        payload={"messages": [], "max_tokens": 222},
++        headers={},
++    )
++
++    assert len(created_clients) == 2
++    assert created_clients[0].is_closed is False
++    assert created_clients[1].is_closed is False
++    await llm_client.LLMClient.close()
++
++
++@pytest.mark.asyncio
++async def test_post_chat_completion_uses_separate_clients_per_timeout_without_closing_active_one(
 +    monkeypatch: pytest.MonkeyPatch,
 +) -> None:
 +    created_clients: list["_FakeClient"] = []
++    loop_token = type("LoopToken", (), {})()
 +
 +    class _FakeResponse:
 +        status_code = 200
@@ -122,42 +226,20 @@ index 2187cfd..103fb27 100644
 +
 +    await llm_client.LLMClient.close()
 +    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
-+    fast_client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
-+    slow_client = llm_client.LLMClient(base_url="http://example.test", timeout=321.0)
-+
-+    await fast_client._post_chat_completion(
-+        url="http://example.test/v1/chat/completions",
-+        payload={"messages": [], "max_tokens": 111},
-+        headers={},
-+    )
-+    await slow_client._post_chat_completion(
-+        url="http://example.test/v1/chat/completions",
-+        payload={"messages": [], "max_tokens": 222},
-+        headers={},
-+    )
-+
-+    assert len(created_clients) == 2
++    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", lambda: loop_token)
+     fast_client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
+     slow_client = llm_client.LLMClient(base_url="http://example.test", timeout=321.0)
+ 
+@@ -230,9 +322,11 @@ async def test_post_chat_completion_recreates_shared_client_when_timeout_changes
+     )
+ 
+     assert len(created_clients) == 2
+-    assert created_clients[0].is_closed is True
++    assert created_clients[0].is_closed is False
+     assert created_clients[1].kwargs["timeout"].read == pytest.approx(321.0)
+     await llm_client.LLMClient.close()
 +    assert created_clients[0].is_closed is True
-+    assert created_clients[1].kwargs["timeout"].read == pytest.approx(321.0)
-+    await llm_client.LLMClient.close()
++    assert created_clients[1].is_closed is True
  
  
  @pytest.mark.asyncio
-@@ -773,7 +829,7 @@ def test_worker_main_closes_shared_http_client_on_shutdown(
-     monkeypatch.setattr(worker_module, "init_db", lambda cfg: calls.setdefault("init_db", cfg))
-     monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
-     monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
--    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
-+    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object(), raising=False)
-     monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
- 
-     class _FakeWorker:
-@@ -834,7 +890,7 @@ def test_worker_main_logs_close_failure_without_masking_worker_error(
-     monkeypatch.setattr(worker_module, "init_db", lambda *_args: None)
-     monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
-     monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
--    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
-+    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object(), raising=False)
-     monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
-     monkeypatch.setattr(
-         worker_module._logger,

--- a/lan_app/worker.py
+++ b/lan_app/worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import signal
 from types import FrameType
@@ -9,6 +10,7 @@ from rq import Worker
 
 from .config import AppSettings
 from .db import init_db
+from lan_transcriber.llm_client import LLMClient
 from .worker_status import start_heartbeat_thread, write_worker_status
 
 _logger = logging.getLogger(__name__)
@@ -38,7 +40,13 @@ def main() -> None:
     connection = Redis.from_url(settings.redis_url)
     worker = Worker([settings.rq_queue_name], connection=connection)
     _install_signal_handlers(worker)
-    worker.work(with_scheduler=False, burst=settings.rq_worker_burst)
+    try:
+        worker.work(with_scheduler=False, burst=settings.rq_worker_burst)
+    finally:
+        try:
+            asyncio.run(LLMClient.close())
+        except Exception:
+            _logger.warning("Failed to close shared LLM HTTP client", exc_info=True)
 
 
 if __name__ == "__main__":

--- a/lan_transcriber/llm_client.py
+++ b/lan_transcriber/llm_client.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+import weakref
 
 import anyio
 import httpx
@@ -217,9 +219,9 @@ class LLMTruncatedResponseError(ValueError):
 class LLMClient:
     """Simple asynchronous client for the language model API."""
 
-    _http_client: httpx.AsyncClient | None = None
-    _http_client_factory: Any = None
-    _http_client_timeout: float | None = None
+    _http_clients: weakref.WeakKeyDictionary[
+        asyncio.AbstractEventLoop, dict[tuple[Any, float], httpx.AsyncClient]
+    ] = weakref.WeakKeyDictionary()
 
     def __init__(
         self,
@@ -258,38 +260,34 @@ class LLMClient:
     async def _get_client(self) -> httpx.AsyncClient:
         cls = type(self)
         current_factory = httpx.AsyncClient
-        client = cls._http_client
-        client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
-        timeout_changed = cls._http_client_timeout != self.timeout
-        if (
-            client is None
-            or client_closed
-            or cls._http_client_factory is not current_factory
-            or timeout_changed
-        ):
-            if client is not None and not client_closed:
-                aclose = getattr(client, "aclose", None)
-                if callable(aclose):
-                    await aclose()
-            cls._http_client = current_factory(
+        loop = asyncio.get_running_loop()
+        loop_clients = cls._http_clients.setdefault(loop, {})
+        client_key = (current_factory, self.timeout)
+        client = loop_clients.get(client_key)
+        if client is None or bool(getattr(client, "is_closed", False)):
+            client = current_factory(
                 timeout=httpx.Timeout(self.timeout),
                 limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
             )
-            cls._http_client_factory = current_factory
-            cls._http_client_timeout = self.timeout
-        return cls._http_client
+            loop_clients[client_key] = client
+        return client
 
     @classmethod
     async def close(cls) -> None:
-        client = cls._http_client
-        cls._http_client = None
-        cls._http_client_factory = None
-        cls._http_client_timeout = None
-        if client is None or bool(getattr(client, "is_closed", False)):
-            return
-        aclose = getattr(client, "aclose", None)
-        if callable(aclose):
-            await aclose()
+        loop_clients = list(cls._http_clients.values())
+        cls._http_clients = weakref.WeakKeyDictionary()
+        closed_ids: set[int] = set()
+        for pool in loop_clients:
+            for client in pool.values():
+                client_id = id(client)
+                if client_id in closed_ids:
+                    continue
+                closed_ids.add(client_id)
+                if client is None or bool(getattr(client, "is_closed", False)):
+                    continue
+                aclose = getattr(client, "aclose", None)
+                if callable(aclose):
+                    await aclose()
 
     @retry(
         wait=wait_exponential(multiplier=1, min=1, max=8),

--- a/lan_transcriber/llm_client.py
+++ b/lan_transcriber/llm_client.py
@@ -7,8 +7,8 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional
-import weakref
+import threading
+from typing import Any, Coroutine, Dict, List, Optional, TypeVar
 
 import anyio
 import httpx
@@ -23,6 +23,7 @@ _DEFAULT_LLM_MAX_TOKENS = 1024
 _MAX_LLM_MAX_TOKENS = 4096
 _HTTP_ERROR_BODY_MAX_CHARS = 2000
 _logger = logging.getLogger(__name__)
+_T = TypeVar("_T")
 
 
 def _timeout_seconds(value: str | None, *, default: float) -> float:
@@ -219,9 +220,10 @@ class LLMTruncatedResponseError(ValueError):
 class LLMClient:
     """Simple asynchronous client for the language model API."""
 
-    _http_clients: weakref.WeakKeyDictionary[
-        asyncio.AbstractEventLoop, dict[tuple[Any, float], httpx.AsyncClient]
-    ] = weakref.WeakKeyDictionary()
+    _http_clients: dict[tuple[Any, float], httpx.AsyncClient] = {}
+    _http_loop: asyncio.AbstractEventLoop | None = None
+    _http_thread: threading.Thread | None = None
+    _http_runtime_lock = threading.Lock()
 
     def __init__(
         self,
@@ -257,37 +259,114 @@ class LLMClient:
         configured_mock_path = mock_response_path or os.getenv("LLM_MOCK_RESPONSE_PATH")
         self.mock_response_path = Path(configured_mock_path) if configured_mock_path else None
 
-    async def _get_client(self) -> httpx.AsyncClient:
+    @classmethod
+    def _ensure_http_runtime(cls) -> asyncio.AbstractEventLoop:
+        with cls._http_runtime_lock:
+            loop = cls._http_loop
+            thread = cls._http_thread
+            if loop is not None and thread is not None and thread.is_alive() and not loop.is_closed():
+                return loop
+
+            ready = threading.Event()
+            runtime: dict[str, asyncio.AbstractEventLoop] = {}
+
+            def _run_http_loop() -> None:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                runtime["loop"] = loop
+                ready.set()
+                loop.run_forever()
+                loop.close()
+
+            thread = threading.Thread(
+                target=_run_http_loop,
+                name="llm-client-http-loop",
+                daemon=True,
+            )
+            cls._http_loop = None
+            cls._http_thread = thread
+            thread.start()
+            ready.wait()
+            loop = runtime["loop"]
+            cls._http_loop = loop
+            return loop
+
+    @staticmethod
+    def _running_loop() -> asyncio.AbstractEventLoop | None:
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
+    @classmethod
+    async def _run_on_http_runtime(cls, coroutine: Coroutine[Any, Any, _T]) -> _T:
+        loop = cls._ensure_http_runtime()
+        current_loop = cls._running_loop()
+        if current_loop is loop:
+            return await coroutine
+        future = asyncio.run_coroutine_threadsafe(coroutine, loop)
+        return await asyncio.wrap_future(future)
+
+    async def _get_or_create_client(self) -> httpx.AsyncClient:
         cls = type(self)
         current_factory = httpx.AsyncClient
-        loop = asyncio.get_running_loop()
-        loop_clients = cls._http_clients.setdefault(loop, {})
         client_key = (current_factory, self.timeout)
-        client = loop_clients.get(client_key)
+        client = cls._http_clients.get(client_key)
         if client is None or bool(getattr(client, "is_closed", False)):
             client = current_factory(
                 timeout=httpx.Timeout(self.timeout),
                 limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
             )
-            loop_clients[client_key] = client
+            cls._http_clients[client_key] = client
         return client
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        return await type(self)._run_on_http_runtime(self._get_or_create_client())
+
+    @classmethod
+    async def _close_clients(cls, clients: list[Any]) -> None:
+        del cls
+        closed_ids: set[int] = set()
+        for client in clients:
+            client_id = id(client)
+            if client_id in closed_ids:
+                continue
+            closed_ids.add(client_id)
+            if client is None or bool(getattr(client, "is_closed", False)):
+                continue
+            aclose = getattr(client, "aclose", None)
+            if callable(aclose):
+                await aclose()
 
     @classmethod
     async def close(cls) -> None:
-        loop_clients = list(cls._http_clients.values())
-        cls._http_clients = weakref.WeakKeyDictionary()
-        closed_ids: set[int] = set()
-        for pool in loop_clients:
-            for client in pool.values():
-                client_id = id(client)
-                if client_id in closed_ids:
-                    continue
-                closed_ids.add(client_id)
-                if client is None or bool(getattr(client, "is_closed", False)):
-                    continue
-                aclose = getattr(client, "aclose", None)
-                if callable(aclose):
-                    await aclose()
+        with cls._http_runtime_lock:
+            loop = cls._http_loop
+            thread = cls._http_thread
+
+        if loop is None or thread is None or not thread.is_alive() or loop.is_closed():
+            clients = list(cls._http_clients.values())
+            cls._http_clients = {}
+            await cls._close_clients(clients)
+            with cls._http_runtime_lock:
+                cls._http_loop = None
+                cls._http_thread = None
+            return
+
+        async def _shutdown_http_runtime() -> None:
+            clients = list(cls._http_clients.values())
+            cls._http_clients = {}
+            await cls._close_clients(clients)
+
+        await cls._run_on_http_runtime(_shutdown_http_runtime())
+        loop.call_soon_threadsafe(loop.stop)
+        if thread is not threading.current_thread():
+            await asyncio.to_thread(thread.join)
+        with cls._http_runtime_lock:
+            if cls._http_loop is loop:
+                cls._http_loop = None
+            if cls._http_thread is thread:
+                cls._http_thread = None
 
     @retry(
         wait=wait_exponential(multiplier=1, min=1, max=8),
@@ -312,9 +391,12 @@ class LLMClient:
             attempt_number if attempt_number is not None else "unknown",
             payload.get("response_format") is not None,
         )
-        client = await self._get_client()
-        with anyio.fail_after(self.timeout):
-            resp = await client.post(url, json=payload, headers=headers)
+        async def _send_request() -> httpx.Response:
+            client = await self._get_or_create_client()
+            with anyio.fail_after(self.timeout):
+                return await client.post(url, json=payload, headers=headers)
+
+        resp = await type(self)._run_on_http_runtime(_send_request())
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:

--- a/lan_transcriber/llm_client.py
+++ b/lan_transcriber/llm_client.py
@@ -217,6 +217,9 @@ class LLMTruncatedResponseError(ValueError):
 class LLMClient:
     """Simple asynchronous client for the language model API."""
 
+    _http_client: httpx.AsyncClient | None = None
+    _http_client_factory: Any = None
+
     def __init__(
         self,
         base_url: str | None = None,
@@ -251,6 +254,34 @@ class LLMClient:
         configured_mock_path = mock_response_path or os.getenv("LLM_MOCK_RESPONSE_PATH")
         self.mock_response_path = Path(configured_mock_path) if configured_mock_path else None
 
+    @classmethod
+    def _get_client(cls) -> httpx.AsyncClient:
+        current_factory = httpx.AsyncClient
+        client = cls._http_client
+        client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
+        if (
+            client is None
+            or client_closed
+            or cls._http_client_factory is not current_factory
+        ):
+            cls._http_client = current_factory(
+                timeout=httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0),
+                limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
+            )
+            cls._http_client_factory = current_factory
+        return cls._http_client
+
+    @classmethod
+    async def close(cls) -> None:
+        client = cls._http_client
+        cls._http_client = None
+        cls._http_client_factory = None
+        if client is None or bool(getattr(client, "is_closed", False)):
+            return
+        aclose = getattr(client, "aclose", None)
+        if callable(aclose):
+            await aclose()
+
     @retry(
         wait=wait_exponential(multiplier=1, min=1, max=8),
         stop=stop_after_attempt(3),
@@ -274,30 +305,30 @@ class LLMClient:
             attempt_number if attempt_number is not None else "unknown",
             payload.get("response_format") is not None,
         )
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            with anyio.fail_after(self.timeout):
-                resp = await client.post(url, json=payload, headers=headers)
-            try:
-                resp.raise_for_status()
-            except httpx.HTTPStatusError as exc:
-                model_label = str(payload.get("model") or "<unset>")
-                message = (
-                    "LLM HTTP request failed "
-                    f"status_code={resp.status_code} "
-                    f"llm_url={url} "
-                    f"model={model_label} "
-                    f"max_tokens={payload.get('max_tokens')} "
-                    f"body={_error_body_snippet(resp)}"
-                )
-                raise httpx.HTTPStatusError(
-                    message,
-                    request=exc.request,
-                    response=exc.response,
-                ) from exc
-            data = resp.json()
-            if not isinstance(data, dict):
-                raise ValueError("LLM response must be a JSON object")
-            return data
+        client = self._get_client()
+        with anyio.fail_after(self.timeout):
+            resp = await client.post(url, json=payload, headers=headers)
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            model_label = str(payload.get("model") or "<unset>")
+            message = (
+                "LLM HTTP request failed "
+                f"status_code={resp.status_code} "
+                f"llm_url={url} "
+                f"model={model_label} "
+                f"max_tokens={payload.get('max_tokens')} "
+                f"body={_error_body_snippet(resp)}"
+            )
+            raise httpx.HTTPStatusError(
+                message,
+                request=exc.request,
+                response=exc.response,
+            ) from exc
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise ValueError("LLM response must be a JSON object")
+        return data
 
     def _load_mock_message(self) -> Dict[str, str] | None:
         if self.mock_response_path is None:

--- a/lan_transcriber/llm_client.py
+++ b/lan_transcriber/llm_client.py
@@ -219,6 +219,7 @@ class LLMClient:
 
     _http_client: httpx.AsyncClient | None = None
     _http_client_factory: Any = None
+    _http_client_timeout: float | None = None
 
     def __init__(
         self,
@@ -254,21 +255,28 @@ class LLMClient:
         configured_mock_path = mock_response_path or os.getenv("LLM_MOCK_RESPONSE_PATH")
         self.mock_response_path = Path(configured_mock_path) if configured_mock_path else None
 
-    @classmethod
-    def _get_client(cls) -> httpx.AsyncClient:
+    async def _get_client(self) -> httpx.AsyncClient:
+        cls = type(self)
         current_factory = httpx.AsyncClient
         client = cls._http_client
         client_closed = bool(getattr(client, "is_closed", False)) if client is not None else True
+        timeout_changed = cls._http_client_timeout != self.timeout
         if (
             client is None
             or client_closed
             or cls._http_client_factory is not current_factory
+            or timeout_changed
         ):
+            if client is not None and not client_closed:
+                aclose = getattr(client, "aclose", None)
+                if callable(aclose):
+                    await aclose()
             cls._http_client = current_factory(
-                timeout=httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0),
+                timeout=httpx.Timeout(self.timeout),
                 limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
             )
             cls._http_client_factory = current_factory
+            cls._http_client_timeout = self.timeout
         return cls._http_client
 
     @classmethod
@@ -276,6 +284,7 @@ class LLMClient:
         client = cls._http_client
         cls._http_client = None
         cls._http_client_factory = None
+        cls._http_client_timeout = None
         if client is None or bool(getattr(client, "is_closed", False)):
             return
         aclose = getattr(client, "aclose", None)
@@ -305,7 +314,7 @@ class LLMClient:
             attempt_number if attempt_number is not None else "unknown",
             payload.get("response_format") is not None,
         )
-        client = self._get_client()
+        client = await self._get_client()
         with anyio.fail_after(self.timeout):
             resp = await client.post(url, json=payload, headers=headers)
         try:

--- a/tasks/QUEUE.md
+++ b/tasks/QUEUE.md
@@ -761,7 +761,7 @@ Queue (in order)
 - Depends on: PR-NOISE-SPEAKER-FILTER-01
 
 152) PR-LLM-CLIENT-POOLING-01: Reuse httpx.AsyncClient across LLM requests with connection pooling
-- Status: TODO
+- Status: DONE
 - Tasks file: tasks/PR-LLM-CLIENT-POOLING-01.md
 - Depends on: PR-LLM-INLINE-EXECUTION-01
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -4,6 +4,7 @@ import logging
 import pathlib
 import sys
 from typing import Any
+import weakref
 
 import httpx
 import pytest
@@ -175,22 +176,54 @@ async def test_close_tolerates_client_without_async_close() -> None:
     class _ClientWithoutClose:
         is_closed = False
 
-    llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
-    llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
-    llm_client.LLMClient._http_client_timeout = 5.0  # noqa: SLF001
+    loop = asyncio.get_running_loop()
+    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
+        {loop: {("factory", 5.0): _ClientWithoutClose()}}
+    )
 
     await llm_client.LLMClient.close()
 
-    assert llm_client.LLMClient._http_client is None  # noqa: SLF001
-    assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
-    assert llm_client.LLMClient._http_client_timeout is None  # noqa: SLF001
+    assert len(llm_client.LLMClient._http_clients) == 0  # noqa: SLF001
 
 
 @pytest.mark.asyncio
-async def test_post_chat_completion_recreates_shared_client_when_timeout_changes(
+async def test_close_skips_duplicate_and_already_closed_clients() -> None:
+    loop = asyncio.get_running_loop()
+    close_calls: list[str] = []
+
+    class _TrackedClient:
+        def __init__(self, name: str, *, is_closed: bool) -> None:
+            self.name = name
+            self.is_closed = is_closed
+
+        async def aclose(self) -> None:
+            close_calls.append(self.name)
+            self.is_closed = True
+
+    shared = _TrackedClient("shared", is_closed=False)
+    closed = _TrackedClient("closed", is_closed=True)
+    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
+        {
+            loop: {
+                ("factory-a", 1.0): shared,
+                ("factory-b", 1.0): shared,
+                ("factory-c", 2.0): closed,
+            }
+        }
+    )
+
+    await llm_client.LLMClient.close()
+
+    assert close_calls == ["shared"]
+    assert len(llm_client.LLMClient._http_clients) == 0  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_post_chat_completion_uses_separate_clients_per_event_loop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     created_clients: list["_FakeClient"] = []
+    active_loop = None
 
     class _FakeResponse:
         status_code = 200
@@ -215,6 +248,65 @@ async def test_post_chat_completion_recreates_shared_client_when_timeout_changes
 
     await llm_client.LLMClient.close()
     monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
+    loop_one = type("LoopToken", (), {})()
+    loop_two = type("LoopToken", (), {})()
+
+    def _get_running_loop():
+        return active_loop
+
+    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", _get_running_loop)
+    client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
+
+    active_loop = loop_one
+    await client._post_chat_completion(
+        url="http://example.test/v1/chat/completions",
+        payload={"messages": [], "max_tokens": 111},
+        headers={},
+    )
+    active_loop = loop_two
+    await client._post_chat_completion(
+        url="http://example.test/v1/chat/completions",
+        payload={"messages": [], "max_tokens": 222},
+        headers={},
+    )
+
+    assert len(created_clients) == 2
+    assert created_clients[0].is_closed is False
+    assert created_clients[1].is_closed is False
+    await llm_client.LLMClient.close()
+
+
+@pytest.mark.asyncio
+async def test_post_chat_completion_uses_separate_clients_per_timeout_without_closing_active_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_clients: list["_FakeClient"] = []
+    loop_token = type("LoopToken", (), {})()
+
+    class _FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            self.is_closed = False
+            created_clients.append(self)
+
+        async def post(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+            return _FakeResponse()
+
+        async def aclose(self) -> None:
+            self.is_closed = True
+
+    await llm_client.LLMClient.close()
+    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", lambda: loop_token)
     fast_client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
     slow_client = llm_client.LLMClient(base_url="http://example.test", timeout=321.0)
 
@@ -230,9 +322,11 @@ async def test_post_chat_completion_recreates_shared_client_when_timeout_changes
     )
 
     assert len(created_clients) == 2
-    assert created_clients[0].is_closed is True
+    assert created_clients[0].is_closed is False
     assert created_clients[1].kwargs["timeout"].read == pytest.approx(321.0)
     await llm_client.LLMClient.close()
+    assert created_clients[0].is_closed is True
+    assert created_clients[1].is_closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -152,10 +152,15 @@ async def test_post_chat_completion_reuses_shared_http_client(
     assert len(created_clients) == 1
     assert created_clients[0].calls[0][1]["max_tokens"] == 111
     assert created_clients[0].calls[1][1]["max_tokens"] == 222
+    timeout = created_clients[0].kwargs["timeout"]
+    assert timeout.connect == pytest.approx(0.1)
+    assert timeout.read == pytest.approx(0.1)
+    assert timeout.write == pytest.approx(0.1)
+    assert timeout.pool == pytest.approx(0.1)
 
     await llm_client.LLMClient.close()
     assert created_clients[0].is_closed is True
-    replacement = client._get_client()
+    replacement = await client._get_client()
     assert len(created_clients) == 2
     assert replacement is created_clients[1]
     assert created_clients[1].kwargs["limits"] == httpx.Limits(
@@ -172,11 +177,62 @@ async def test_close_tolerates_client_without_async_close() -> None:
 
     llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
     llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
+    llm_client.LLMClient._http_client_timeout = 5.0  # noqa: SLF001
 
     await llm_client.LLMClient.close()
 
     assert llm_client.LLMClient._http_client is None  # noqa: SLF001
     assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
+    assert llm_client.LLMClient._http_client_timeout is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_post_chat_completion_recreates_shared_client_when_timeout_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_clients: list["_FakeClient"] = []
+
+    class _FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            self.is_closed = False
+            created_clients.append(self)
+
+        async def post(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+            return _FakeResponse()
+
+        async def aclose(self) -> None:
+            self.is_closed = True
+
+    await llm_client.LLMClient.close()
+    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
+    fast_client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
+    slow_client = llm_client.LLMClient(base_url="http://example.test", timeout=321.0)
+
+    await fast_client._post_chat_completion(
+        url="http://example.test/v1/chat/completions",
+        payload={"messages": [], "max_tokens": 111},
+        headers={},
+    )
+    await slow_client._post_chat_completion(
+        url="http://example.test/v1/chat/completions",
+        payload={"messages": [], "max_tokens": 222},
+        headers={},
+    )
+
+    assert len(created_clients) == 2
+    assert created_clients[0].is_closed is True
+    assert created_clients[1].kwargs["timeout"].read == pytest.approx(321.0)
+    await llm_client.LLMClient.close()
 
 
 @pytest.mark.asyncio
@@ -773,7 +829,7 @@ def test_worker_main_closes_shared_http_client_on_shutdown(
     monkeypatch.setattr(worker_module, "init_db", lambda cfg: calls.setdefault("init_db", cfg))
     monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
     monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
-    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
+    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object(), raising=False)
     monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
 
     class _FakeWorker:
@@ -834,7 +890,7 @@ def test_worker_main_logs_close_failure_without_masking_worker_error(
     monkeypatch.setattr(worker_module, "init_db", lambda *_args: None)
     monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
     monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
-    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
+    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object(), raising=False)
     monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
     monkeypatch.setattr(
         worker_module._logger,

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -98,6 +98,88 @@ async def test_generate_payload_includes_max_tokens() -> None:
 
 
 @pytest.mark.asyncio
+async def test_post_chat_completion_reuses_shared_http_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_clients: list["_FakeClient"] = []
+
+    class _FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            self.is_closed = False
+            self.calls: list[tuple[str, dict[str, Any], dict[str, str]]] = []
+            created_clients.append(self)
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict[str, Any],
+            headers: dict[str, str],
+        ) -> _FakeResponse:
+            self.calls.append((url, json, headers))
+            return _FakeResponse()
+
+        async def aclose(self) -> None:
+            self.is_closed = True
+
+    await llm_client.LLMClient.close()
+    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
+    client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
+
+    first = await client._post_chat_completion(
+        url="http://example.test/v1/chat/completions",
+        payload={"messages": [], "max_tokens": 111},
+        headers={"Authorization": "Bearer secret"},
+    )
+    second = await client._post_chat_completion(
+        url="http://example.test/v1/chat/completions",
+        payload={"messages": [], "max_tokens": 222},
+        headers={},
+    )
+
+    assert first["choices"][0]["message"]["content"] == "ok"
+    assert second["choices"][0]["message"]["content"] == "ok"
+    assert len(created_clients) == 1
+    assert created_clients[0].calls[0][1]["max_tokens"] == 111
+    assert created_clients[0].calls[1][1]["max_tokens"] == 222
+
+    await llm_client.LLMClient.close()
+    assert created_clients[0].is_closed is True
+    replacement = client._get_client()
+    assert len(created_clients) == 2
+    assert replacement is created_clients[1]
+    assert created_clients[1].kwargs["limits"] == httpx.Limits(
+        max_connections=5,
+        max_keepalive_connections=2,
+    )
+    await llm_client.LLMClient.close()
+
+
+@pytest.mark.asyncio
+async def test_close_tolerates_client_without_async_close() -> None:
+    class _ClientWithoutClose:
+        is_closed = False
+
+    llm_client.LLMClient._http_client = _ClientWithoutClose()  # noqa: SLF001
+    llm_client.LLMClient._http_client_factory = object()  # noqa: SLF001
+
+    await llm_client.LLMClient.close()
+
+    assert llm_client.LLMClient._http_client is None  # noqa: SLF001
+    assert llm_client.LLMClient._http_client_factory is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 @respx.mock
 async def test_generate_omits_model_when_not_configured() -> None:
     route = respx.post("http://127.0.0.1:8000/v1/chat/completions").mock(
@@ -663,3 +745,121 @@ async def test_generate_debug_log_uses_safe_request_metadata(caplog: pytest.LogC
     assert "response_format=True" in debug_messages
     assert "system-super-secret" not in debug_messages
     assert "user-ultra-secret" not in debug_messages
+
+
+def test_worker_main_closes_shared_http_client_on_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+    import types
+
+    monkeypatch.setitem(sys.modules, "redis", types.SimpleNamespace(Redis=type("Redis", (), {})))
+    monkeypatch.setitem(sys.modules, "rq", types.SimpleNamespace(Worker=type("Worker", (), {})))
+    worker_module = importlib.import_module("lan_app.worker")
+
+    calls: dict[str, object] = {}
+    settings = type(
+        "Settings",
+        (),
+        {
+            "redis_url": "redis://unit",
+            "rq_queue_name": "audio",
+            "rq_worker_burst": False,
+            "data_root": pathlib.Path("/tmp/worker-llm-close"),
+        },
+    )()
+
+    monkeypatch.setattr(worker_module, "AppSettings", lambda: settings)
+    monkeypatch.setattr(worker_module, "init_db", lambda cfg: calls.setdefault("init_db", cfg))
+    monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
+    monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
+    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
+    monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
+
+    class _FakeWorker:
+        def __init__(self, queues, *, connection):
+            calls["queues"] = queues
+            calls["connection"] = connection
+
+        def work(self, *, with_scheduler, burst):
+            calls["work"] = (with_scheduler, burst)
+            raise RuntimeError("boom")
+
+    async def _fake_close(_cls) -> None:
+        calls["close_count"] = int(calls.get("close_count", 0)) + 1
+
+    original_asyncio_run = asyncio.run
+
+    def _run_coroutine(coro):
+        calls["asyncio_run_called"] = True
+        return original_asyncio_run(coro)
+
+    monkeypatch.setattr(worker_module, "Worker", _FakeWorker)
+    monkeypatch.setattr(worker_module.asyncio, "run", _run_coroutine)
+    monkeypatch.setattr(worker_module.LLMClient, "close", classmethod(_fake_close))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        worker_module.main()
+
+    assert calls["init_db"] is settings
+    assert calls["queues"] == ["audio"]
+    assert calls["work"] == (False, False)
+    assert calls["asyncio_run_called"] is True
+    assert calls["close_count"] == 1
+
+
+def test_worker_main_logs_close_failure_without_masking_worker_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+    import types
+
+    monkeypatch.setitem(sys.modules, "redis", types.SimpleNamespace(Redis=type("Redis", (), {})))
+    monkeypatch.setitem(sys.modules, "rq", types.SimpleNamespace(Worker=type("Worker", (), {})))
+    worker_module = importlib.import_module("lan_app.worker")
+
+    calls: dict[str, object] = {}
+    settings = type(
+        "Settings",
+        (),
+        {
+            "redis_url": "redis://unit",
+            "rq_queue_name": "audio",
+            "rq_worker_burst": False,
+            "data_root": pathlib.Path("/tmp/worker-llm-close-warning"),
+        },
+    )()
+
+    monkeypatch.setattr(worker_module, "AppSettings", lambda: settings)
+    monkeypatch.setattr(worker_module, "init_db", lambda *_args: None)
+    monkeypatch.setattr(worker_module, "write_worker_status", lambda *_args: None)
+    monkeypatch.setattr(worker_module, "start_heartbeat_thread", lambda *_args: (None, None))
+    monkeypatch.setattr(worker_module.Redis, "from_url", lambda _url: object())
+    monkeypatch.setattr(worker_module, "_install_signal_handlers", lambda _worker: None)
+    monkeypatch.setattr(
+        worker_module._logger,
+        "warning",
+        lambda message, **kwargs: calls.update({"warning": message, "warning_kwargs": kwargs}),
+    )
+
+    class _FakeWorker:
+        def __init__(self, queues, *, connection):
+            calls["queues"] = queues
+            calls["connection"] = connection
+
+        def work(self, *, with_scheduler, burst):
+            calls["work"] = (with_scheduler, burst)
+            raise RuntimeError("worker-boom")
+
+    def _run_coroutine(coro):
+        coro.close()
+        raise RuntimeError("close-boom")
+
+    monkeypatch.setattr(worker_module, "Worker", _FakeWorker)
+    monkeypatch.setattr(worker_module.asyncio, "run", _run_coroutine)
+
+    with pytest.raises(RuntimeError, match="worker-boom"):
+        worker_module.main()
+
+    assert calls["warning"] == "Failed to close shared LLM HTTP client"
+    assert calls["warning_kwargs"] == {"exc_info": True}

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -4,7 +4,6 @@ import logging
 import pathlib
 import sys
 from typing import Any
-import weakref
 
 import httpx
 import pytest
@@ -98,8 +97,7 @@ async def test_generate_payload_includes_max_tokens() -> None:
     assert payload["max_tokens"] == 1536
 
 
-@pytest.mark.asyncio
-async def test_post_chat_completion_reuses_shared_http_client(
+def test_post_chat_completion_reuses_shared_http_client_across_asyncio_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     created_clients: list["_FakeClient"] = []
@@ -133,20 +131,19 @@ async def test_post_chat_completion_reuses_shared_http_client(
         async def aclose(self) -> None:
             self.is_closed = True
 
-    await llm_client.LLMClient.close()
     monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
     client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
 
-    first = await client._post_chat_completion(
-        url="http://example.test/v1/chat/completions",
-        payload={"messages": [], "max_tokens": 111},
-        headers={"Authorization": "Bearer secret"},
-    )
-    second = await client._post_chat_completion(
-        url="http://example.test/v1/chat/completions",
-        payload={"messages": [], "max_tokens": 222},
-        headers={},
-    )
+    async def _post(max_tokens: int, headers: dict[str, str]) -> dict[str, Any]:
+        return await client._post_chat_completion(
+            url="http://example.test/v1/chat/completions",
+            payload={"messages": [], "max_tokens": max_tokens},
+            headers=headers,
+        )
+
+    asyncio.run(llm_client.LLMClient.close())
+    first = asyncio.run(_post(111, {"Authorization": "Bearer secret"}))
+    second = asyncio.run(_post(222, {}))
 
     assert first["choices"][0]["message"]["content"] == "ok"
     assert second["choices"][0]["message"]["content"] == "ok"
@@ -159,16 +156,16 @@ async def test_post_chat_completion_reuses_shared_http_client(
     assert timeout.write == pytest.approx(0.1)
     assert timeout.pool == pytest.approx(0.1)
 
-    await llm_client.LLMClient.close()
+    asyncio.run(llm_client.LLMClient.close())
     assert created_clients[0].is_closed is True
-    replacement = await client._get_client()
+    replacement = asyncio.run(client._get_client())
     assert len(created_clients) == 2
     assert replacement is created_clients[1]
     assert created_clients[1].kwargs["limits"] == httpx.Limits(
         max_connections=5,
         max_keepalive_connections=2,
     )
-    await llm_client.LLMClient.close()
+    asyncio.run(llm_client.LLMClient.close())
 
 
 @pytest.mark.asyncio
@@ -176,10 +173,7 @@ async def test_close_tolerates_client_without_async_close() -> None:
     class _ClientWithoutClose:
         is_closed = False
 
-    loop = asyncio.get_running_loop()
-    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
-        {loop: {("factory", 5.0): _ClientWithoutClose()}}
-    )
+    llm_client.LLMClient._http_clients = {("factory", 5.0): _ClientWithoutClose()}  # noqa: SLF001
 
     await llm_client.LLMClient.close()
 
@@ -188,7 +182,6 @@ async def test_close_tolerates_client_without_async_close() -> None:
 
 @pytest.mark.asyncio
 async def test_close_skips_duplicate_and_already_closed_clients() -> None:
-    loop = asyncio.get_running_loop()
     close_calls: list[str] = []
 
     class _TrackedClient:
@@ -202,15 +195,11 @@ async def test_close_skips_duplicate_and_already_closed_clients() -> None:
 
     shared = _TrackedClient("shared", is_closed=False)
     closed = _TrackedClient("closed", is_closed=True)
-    llm_client.LLMClient._http_clients = weakref.WeakKeyDictionary(  # noqa: SLF001
-        {
-            loop: {
-                ("factory-a", 1.0): shared,
-                ("factory-b", 1.0): shared,
-                ("factory-c", 2.0): closed,
-            }
-        }
-    )
+    llm_client.LLMClient._http_clients = {  # noqa: SLF001
+        ("factory-a", 1.0): shared,
+        ("factory-b", 1.0): shared,
+        ("factory-c", 2.0): closed,
+    }
 
     await llm_client.LLMClient.close()
 
@@ -218,12 +207,10 @@ async def test_close_skips_duplicate_and_already_closed_clients() -> None:
     assert len(llm_client.LLMClient._http_clients) == 0  # noqa: SLF001
 
 
-@pytest.mark.asyncio
-async def test_post_chat_completion_uses_separate_clients_per_event_loop(
+def test_post_chat_completion_reuses_shared_http_client_across_event_loops(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     created_clients: list["_FakeClient"] = []
-    active_loop = None
 
     class _FakeResponse:
         status_code = 200
@@ -246,34 +233,59 @@ async def test_post_chat_completion_uses_separate_clients_per_event_loop(
         async def aclose(self) -> None:
             self.is_closed = True
 
-    await llm_client.LLMClient.close()
     monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
-    loop_one = type("LoopToken", (), {})()
-    loop_two = type("LoopToken", (), {})()
-
-    def _get_running_loop():
-        return active_loop
-
-    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", _get_running_loop)
     client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
 
-    active_loop = loop_one
-    await client._post_chat_completion(
-        url="http://example.test/v1/chat/completions",
-        payload={"messages": [], "max_tokens": 111},
-        headers={},
+    async def _post(max_tokens: int) -> None:
+        await client._post_chat_completion(
+            url="http://example.test/v1/chat/completions",
+            payload={"messages": [], "max_tokens": max_tokens},
+            headers={},
+        )
+
+    asyncio.run(llm_client.LLMClient.close())
+    asyncio.run(_post(111))
+    asyncio.run(_post(222))
+
+    assert len(created_clients) == 1
+    assert created_clients[0].is_closed is False
+    asyncio.run(llm_client.LLMClient.close())
+
+
+def test_running_loop_returns_none_without_active_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_runtime_error() -> None:
+        raise RuntimeError("no running event loop")
+
+    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", _raise_runtime_error)
+
+    assert llm_client.LLMClient._running_loop() is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_run_on_http_runtime_awaits_inline_when_already_on_http_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop = asyncio.get_running_loop()
+
+    async def _inline() -> str:
+        return "inline"
+
+    monkeypatch.setattr(
+        llm_client.LLMClient,
+        "_ensure_http_runtime",
+        classmethod(lambda cls: loop),
     )
-    active_loop = loop_two
-    await client._post_chat_completion(
-        url="http://example.test/v1/chat/completions",
-        payload={"messages": [], "max_tokens": 222},
-        headers={},
+    monkeypatch.setattr(
+        llm_client.LLMClient,
+        "_running_loop",
+        staticmethod(lambda: loop),
     )
 
-    assert len(created_clients) == 2
-    assert created_clients[0].is_closed is False
-    assert created_clients[1].is_closed is False
-    await llm_client.LLMClient.close()
+    result = await llm_client.LLMClient._run_on_http_runtime(_inline())  # noqa: SLF001
+
+    assert result == "inline"
 
 
 @pytest.mark.asyncio
@@ -281,7 +293,6 @@ async def test_post_chat_completion_uses_separate_clients_per_timeout_without_cl
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     created_clients: list["_FakeClient"] = []
-    loop_token = type("LoopToken", (), {})()
 
     class _FakeResponse:
         status_code = 200
@@ -306,7 +317,6 @@ async def test_post_chat_completion_uses_separate_clients_per_timeout_without_cl
 
     await llm_client.LLMClient.close()
     monkeypatch.setattr(llm_client.httpx, "AsyncClient", _FakeClient)
-    monkeypatch.setattr(llm_client.asyncio, "get_running_loop", lambda: loop_token)
     fast_client = llm_client.LLMClient(base_url="http://example.test", timeout=0.1)
     slow_client = llm_client.LLMClient(base_url="http://example.test", timeout=321.0)
 
@@ -327,6 +337,83 @@ async def test_post_chat_completion_uses_separate_clients_per_timeout_without_cl
     await llm_client.LLMClient.close()
     assert created_clients[0].is_closed is True
     assert created_clients[1].is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_close_skips_join_and_cleanup_reset_when_runtime_state_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_calls: list[str] = []
+
+    class _Loop:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.stopped = False
+
+        def is_closed(self) -> bool:
+            return False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+        def call_soon_threadsafe(self, callback: Any) -> None:
+            stop_calls.append(self.name)
+            callback()
+
+    class _Thread:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def is_alive(self) -> bool:
+            return True
+
+    class _TrackedClient:
+        def __init__(self) -> None:
+            self.is_closed = False
+
+        async def aclose(self) -> None:
+            self.is_closed = True
+
+    loop = _Loop("active")
+    replacement_loop = _Loop("replacement")
+    thread = _Thread("active")
+    replacement_thread = _Thread("replacement")
+    client = _TrackedClient()
+    original_clients = llm_client.LLMClient._http_clients  # noqa: SLF001
+    original_loop = llm_client.LLMClient._http_loop  # noqa: SLF001
+    original_thread = llm_client.LLMClient._http_thread  # noqa: SLF001
+
+    try:
+        llm_client.LLMClient._http_clients = {("factory", 1.0): client}  # noqa: SLF001
+        llm_client.LLMClient._http_loop = loop  # noqa: SLF001
+        llm_client.LLMClient._http_thread = thread  # noqa: SLF001
+
+        async def _fake_run_on_http_runtime(
+            cls: type[llm_client.LLMClient],
+            coroutine: Any,
+        ) -> None:
+            await coroutine
+            cls._http_loop = replacement_loop  # noqa: SLF001
+            cls._http_thread = replacement_thread  # noqa: SLF001
+
+        monkeypatch.setattr(
+            llm_client.LLMClient,
+            "_run_on_http_runtime",
+            classmethod(_fake_run_on_http_runtime),
+        )
+        monkeypatch.setattr(llm_client.threading, "current_thread", lambda: thread)
+
+        await llm_client.LLMClient.close()
+
+        assert client.is_closed is True
+        assert stop_calls == ["active"]
+        assert loop.stopped is True
+        assert llm_client.LLMClient._http_loop is replacement_loop  # noqa: SLF001
+        assert llm_client.LLMClient._http_thread is replacement_thread  # noqa: SLF001
+    finally:
+        llm_client.LLMClient._http_clients = original_clients  # noqa: SLF001
+        llm_client.LLMClient._http_loop = original_loop  # noqa: SLF001
+        llm_client.LLMClient._http_thread = original_thread  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
PR_ID: PR-LLM-CLIENT-POOLING-01
TASK_FILE: tasks/PR-LLM-CLIENT-POOLING-01.md
Branch: pr-llm-client-pooling-01

What changed
- Reused a lazily initialized shared `httpx.AsyncClient` inside `LLMClient` instead of creating a new client per request.
- Added `LLMClient.close()` so the shared client can be released cleanly.
- Closed the shared LLM client when the worker shuts down.
- Added regression coverage for client reuse, close edge cases, and worker shutdown cleanup.
- Updated `tasks/QUEUE.md` from `DOING` to `DONE`.

How verified
- `./scripts/ci.sh`

Artifacts
- `artifacts/ci.log`
- `artifacts/pr.patch`

Manual test steps
- Not applicable

MCP usage
- None