### PR TITLE
PR-REUPLOAD-REPROCESS-01: Force full reprocess when re-uploading an existing audio file

### DIFF
--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -104,8 +104,8 @@ Requirement already satisfied: pytz>2021.1 in ./.venv-ci/lib/python3.12/site-pac
 Building wheels for collected packages: lan-transcriber
   Building editable for lan-transcriber (pyproject.toml): started
   Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
-  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=935ef227ad79ba0bce1e66e2719b258fcfe3cda370b0985c9bf5ac2cc41c9f42
-  Stored in directory: /tmp/pip-ephem-wheel-cache-vf0pyrgc/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=57eb4cab2c49a1ed4b33bc8f7150e09802c3d1416d6af77251dcc62a803e8df6
+  Stored in directory: /tmp/pip-ephem-wheel-cache-48j87x16/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
 Successfully built lan-transcriber
 Installing collected packages: lan-transcriber
   Attempting uninstall: lan-transcriber
@@ -137,7 +137,7 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [ 85%]
 ........................................................................ [ 90%]
 ........................................................................ [ 95%]
-.......................................................                  [100%]
+........................................................                 [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -176,13 +176,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.12.3-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   15412      0   5156      0   100%
+TOTAL   15419      0   5158      0   100%
 
 67 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1350 passed, 2 skipped, 11 warnings in 136.62s (0:02:16)
+1351 passed, 2 skipped, 11 warnings in 136.04s (0:02:16)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -220,7 +220,7 @@ TOTAL                                                    4860      0   1682     
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%
-lan_app/api.py                       360      0     86      0   100%
+lan_app/api.py                       363      0     86      0   100%
 lan_app/asr_glossary.py              224      0     98      0   100%
 lan_app/auth.py                       58      0     20      0   100%
 lan_app/calendar/__init__.py           4      0      0      0   100%
@@ -251,10 +251,10 @@ lan_app/tools/repair_snippets.py      36      0     12      0   100%
 lan_app/tools/warm_models.py          47      0     10      0   100%
 lan_app/ui.py                         59      0     10      0   100%
 lan_app/ui_routes.py                2692      0   1024      0   100%
-lan_app/uploads.py                   111      0     26      0   100%
+lan_app/uploads.py                   115      0     28      0   100%
 lan_app/worker.py                     38      0      2      0   100%
 lan_app/worker_status.py              58      0      6      0   100%
 lan_app/worker_tasks.py             1853      0    536      0   100%
 lan_app/workers.py                    10      0      0      0   100%
 --------------------------------------------------------------------
-TOTAL                              10552      0   3474      0   100%
+TOTAL                              10559      0   3476      0   100%

--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -104,8 +104,8 @@ Requirement already satisfied: pytz>2021.1 in ./.venv-ci/lib/python3.12/site-pac
 Building wheels for collected packages: lan-transcriber
   Building editable for lan-transcriber (pyproject.toml): started
   Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
-  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=47a7fd647bfb9f31943dc5edd2710774976be5035776b752acb0880712adaa57
-  Stored in directory: /tmp/pip-ephem-wheel-cache-g7iza6xs/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=935ef227ad79ba0bce1e66e2719b258fcfe3cda370b0985c9bf5ac2cc41c9f42
+  Stored in directory: /tmp/pip-ephem-wheel-cache-vf0pyrgc/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
 Successfully built lan-transcriber
 Installing collected packages: lan-transcriber
   Attempting uninstall: lan-transcriber
@@ -121,23 +121,23 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
   warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
 ........................................................................ [  5%]
 ........................................................................ [ 10%]
-........................................................................ [ 16%]
+........................................................................ [ 15%]
 ........................................................................ [ 21%]
 ........................................................................ [ 26%]
-........................................................................ [ 32%]
+........................................................................ [ 31%]
 ........................................................................ [ 37%]
 ........................................................................ [ 42%]
-........................................................................ [ 48%]
+........................................................................ [ 47%]
 ........................................................................ [ 53%]
 ........................................................................ [ 58%]
-........................................................................ [ 64%]
+........................................................................ [ 63%]
 ........................................................................ [ 69%]
 ........................................s............................... [ 74%]
-........................................................................ [ 80%]
+........................................................................ [ 79%]
 ........................................................................ [ 85%]
 ........................................................................ [ 90%]
-........................................................................ [ 96%]
-......................................................                   [100%]
+........................................................................ [ 95%]
+.......................................................                  [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -176,13 +176,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.12.3-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   15408      0   5152      0   100%
+TOTAL   15412      0   5156      0   100%
 
 67 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1349 passed, 2 skipped, 11 warnings in 142.14s (0:02:22)
+1350 passed, 2 skipped, 11 warnings in 136.62s (0:02:16)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -220,7 +220,7 @@ TOTAL                                                    4860      0   1682     
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%
-lan_app/api.py                       356      0     82      0   100%
+lan_app/api.py                       360      0     86      0   100%
 lan_app/asr_glossary.py              224      0     98      0   100%
 lan_app/auth.py                       58      0     20      0   100%
 lan_app/calendar/__init__.py           4      0      0      0   100%
@@ -257,4 +257,4 @@ lan_app/worker_status.py              58      0      6      0   100%
 lan_app/worker_tasks.py             1853      0    536      0   100%
 lan_app/workers.py                    10      0      0      0   100%
 --------------------------------------------------------------------
-TOTAL                              10548      0   3470      0   100%
+TOTAL                              10552      0   3474      0   100%

--- a/artifacts/ci.log
+++ b/artifacts/ci.log
@@ -104,8 +104,8 @@ Requirement already satisfied: pytz>2021.1 in ./.venv-ci/lib/python3.12/site-pac
 Building wheels for collected packages: lan-transcriber
   Building editable for lan-transcriber (pyproject.toml): started
   Building editable for lan-transcriber (pyproject.toml): finished with status 'done'
-  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=cfb9a295970c3a2c8b63ae405725f0587e318281ff51d54ecd707739b842ee04
-  Stored in directory: /tmp/pip-ephem-wheel-cache-qh_r66k7/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
+  Created wheel for lan-transcriber: filename=lan_transcriber-0.1.0-0.editable-py3-none-any.whl size=15475 sha256=47a7fd647bfb9f31943dc5edd2710774976be5035776b752acb0880712adaa57
+  Stored in directory: /tmp/pip-ephem-wheel-cache-g7iza6xs/wheels/d5/8a/5c/f7178f7e49aa5ae12b2320ec66b5c310f4f2f63d1bd301b7fb
 Successfully built lan-transcriber
 Installing collected packages: lan-transcriber
   Attempting uninstall: lan-transcriber
@@ -129,15 +129,15 @@ The event loop scope for asynchronous fixtures will default to the fixture cachi
 ........................................................................ [ 42%]
 ........................................................................ [ 48%]
 ........................................................................ [ 53%]
-........................................................................ [ 59%]
+........................................................................ [ 58%]
 ........................................................................ [ 64%]
 ........................................................................ [ 69%]
-........................................s............................... [ 75%]
+........................................s............................... [ 74%]
 ........................................................................ [ 80%]
 ........................................................................ [ 85%]
-........................................................................ [ 91%]
+........................................................................ [ 90%]
 ........................................................................ [ 96%]
-.............................................                            [100%]
+......................................................                   [100%]
 =============================== warnings summary ===============================
 lan_transcriber/pipeline_steps/precheck.py:3
   /home/alexey/LAN_Transcriber/lan_transcriber/pipeline_steps/precheck.py:3: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
@@ -176,13 +176,13 @@ tests/test_warm_models.py::test_warm_models_module_main_guard
 ---------- coverage: platform linux, python 3.12.3-final-0 -----------
 Name    Stmts   Miss Branch BrPart  Cover   Missing
 ---------------------------------------------------
-TOTAL   15362      0   5138      0   100%
+TOTAL   15408      0   5152      0   100%
 
 67 files skipped due to complete coverage.
 Coverage HTML written to dir htmlcov
 
 Required test coverage of 100% reached. Total coverage: 100.00%
-1340 passed, 2 skipped, 11 warnings in 145.21s (0:02:25)
+1349 passed, 2 skipped, 11 warnings in 142.14s (0:02:22)
 Name                                                    Stmts   Miss Branch BrPart  Cover
 -----------------------------------------------------------------------------------------
 lan_transcriber/__init__.py                                 8      0      0      0   100%
@@ -220,7 +220,7 @@ TOTAL                                                    4860      0   1682     
 Name                               Stmts   Miss Branch BrPart  Cover
 --------------------------------------------------------------------
 lan_app/__init__.py                    1      0      0      0   100%
-lan_app/api.py                       342      0     80      0   100%
+lan_app/api.py                       356      0     82      0   100%
 lan_app/asr_glossary.py              224      0     98      0   100%
 lan_app/auth.py                       58      0     20      0   100%
 lan_app/calendar/__init__.py           4      0      0      0   100%
@@ -251,10 +251,10 @@ lan_app/tools/repair_snippets.py      36      0     12      0   100%
 lan_app/tools/warm_models.py          47      0     10      0   100%
 lan_app/ui.py                         59      0     10      0   100%
 lan_app/ui_routes.py                2692      0   1024      0   100%
-lan_app/uploads.py                    79      0     14      0   100%
+lan_app/uploads.py                   111      0     26      0   100%
 lan_app/worker.py                     38      0      2      0   100%
 lan_app/worker_status.py              58      0      6      0   100%
 lan_app/worker_tasks.py             1853      0    536      0   100%
 lan_app/workers.py                    10      0      0      0   100%
 --------------------------------------------------------------------
-TOTAL                              10502      0   3456      0   100%
+TOTAL                              10548      0   3470      0   100%

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,285 +1,34 @@
 diff --git a/lan_app/api.py b/lan_app/api.py
-index dff90f7..3cd053a 100644
+index 3cd053a..4842356 100644
 --- a/lan_app/api.py
 +++ b/lan_app/api.py
-@@ -63,6 +63,7 @@ from .ops import RecordingDeleteError, delete_recording_with_artifacts
- from .reaper import run_stuck_job_reaper_once
- from .uploads import (
-     ALLOWED_UPLOAD_EXTENSIONS,
-+    find_matching_upload_recording,
-     infer_upload_capture_time,
-     safe_filename,
-     suffix_from_name,
-@@ -535,6 +536,7 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
-     raw_dir = recording_dir / "raw"
-     dest = raw_dir / f"audio{ext}"
-     completed = False
-+    cleanup_uploaded_recording_dir = False
-     recording_created = False
- 
-     try:
-@@ -547,6 +549,42 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
-             file.filename or "",
-             upload_capture_timezone=_settings.upload_capture_tzinfo(),
+@@ -554,8 +554,16 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
+             settings=_settings,
          )
-+        matched_recording_id = find_matching_upload_recording(
-+            dest,
-+            settings=_settings,
-+        )
-+        if matched_recording_id is not None:
-+            cleanup_uploaded_recording_dir = True
-+            existing = get_recording(matched_recording_id, settings=_settings)
-+            _logger.info(
-+                "re-upload detected for %s, clearing derived artifacts for full reprocess",
-+                matched_recording_id,
-+            )
-+            try:
-+                job = enqueue_recording_job(
+         if matched_recording_id is not None:
+-            cleanup_uploaded_recording_dir = True
+             existing = get_recording(matched_recording_id, settings=_settings)
++            if existing is None:
++                _logger.warning(
++                    "duplicate upload matched raw audio for %s but no recording row exists; treating upload as new",
 +                    matched_recording_id,
-+                    job_type=JOB_TYPE_PRECHECK,
-+                    force_reprocess=True,
-+                    settings=_settings,
 +                )
-+            except DuplicateRecordingJobError as exc:
-+                raise HTTPException(
-+                    status_code=409,
-+                    detail={
-+                        "message": "A precheck job is already queued or started for this recording.",
-+                        "existing_job_id": exc.job_id,
-+                    },
-+                )
-+            except Exception as exc:
-+                raise HTTPException(status_code=503, detail=f"Queue unavailable: {exc}")
-+
-+            completed = True
-+            return {
-+                "recording_id": matched_recording_id,
-+                "job_id": job.job_id,
-+                "captured_at": str(existing["captured_at"]),
-+                "bytes_written": bytes_written,
-+            }
-         create_recording(
-             recording_id,
-             source="upload",
-@@ -599,7 +637,7 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
-         raise HTTPException(status_code=503, detail=f"Upload failed: {exc}")
-     finally:
-         await file.close()
--        if not completed and recording_dir.exists():
-+        if (not completed or cleanup_uploaded_recording_dir) and recording_dir.exists():
-             shutil.rmtree(recording_dir, ignore_errors=True)
-         if not completed and recording_created:
-             with suppress(Exception):
-diff --git a/lan_app/uploads.py b/lan_app/uploads.py
-index 3e0c50c..a0d5f5a 100644
---- a/lan_app/uploads.py
-+++ b/lan_app/uploads.py
-@@ -2,11 +2,15 @@ from __future__ import annotations
- 
- from dataclasses import dataclass
- from datetime import datetime, timezone
-+import hashlib
- from pathlib import Path
- import re
-+import stat
- from typing import BinaryIO
- from zoneinfo import ZoneInfo
- 
-+from .config import AppSettings
-+
- ALLOWED_UPLOAD_EXTENSIONS = {
-     ".mp3",
-     ".wav",
-@@ -151,9 +155,48 @@ def write_upload_to_path(upload, dest: Path, *, max_bytes: int | None) -> int:
-     return bytes_written
- 
- 
-+def _sha256_file(path: Path) -> str:
-+    digest = hashlib.sha256()
-+    with path.open("rb") as fh:
-+        while True:
-+            chunk = fh.read(_COPY_CHUNK_SIZE)
-+            if not chunk:
-+                break
-+            digest.update(chunk)
-+    return digest.hexdigest()
-+
-+
-+def find_matching_upload_recording(
-+    upload_path: Path,
-+    *,
-+    settings: AppSettings,
-+) -> str | None:
-+    try:
-+        upload_stat = upload_path.stat()
-+    except OSError:
-+        return None
-+    if not stat.S_ISREG(upload_stat.st_mode):
-+        return None
-+    upload_size = upload_stat.st_size
-+    upload_digest = _sha256_file(upload_path)
-+
-+    for raw_audio in sorted(settings.recordings_root.glob("*/raw/audio.*")):
-+        if raw_audio == upload_path:
-+            continue
-+        try:
-+            if raw_audio.stat().st_size != upload_size:
-+                continue
-+            if _sha256_file(raw_audio) == upload_digest:
-+                return raw_audio.parent.parent.name
-+        except OSError:
-+            continue
-+    return None
-+
-+
- __all__ = [
-     "ALLOWED_UPLOAD_EXTENSIONS",
-     "CaptureTimeInference",
-+    "find_matching_upload_recording",
-     "infer_captured_at",
-     "infer_upload_capture_time",
-     "normalize_plaud_captured_at",
-diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
-index 22541fd..928d8f3 100644
---- a/tasks/QUEUE.md
-+++ b/tasks/QUEUE.md
-@@ -776,6 +776,6 @@ Queue (in order)
- - Depends on: PR-LLM-INLINE-EXECUTION-01
- 
- 155) PR-REUPLOAD-REPROCESS-01: Force full reprocess when re-uploading an existing audio file
--- Status: TODO
-+- Status: DONE
- - Tasks file: tasks/PR-REUPLOAD-REPROCESS-01.md
- - Depends on: PR-FORCE-REPROCESS-01
++                matched_recording_id = None
++            else:
++                cleanup_uploaded_recording_dir = True
++        if matched_recording_id is not None:
+             _logger.info(
+                 "re-upload detected for %s, clearing derived artifacts for full reprocess",
+                 matched_recording_id,
 diff --git a/tests/test_upload.py b/tests/test_upload.py
-index b884dfc..6e6b050 100644
+index 6e6b050..162524e 100644
 --- a/tests/test_upload.py
 +++ b/tests/test_upload.py
-@@ -10,6 +10,7 @@ from lan_app import api, uploads
- from lan_app.config import AppSettings
- from lan_app.constants import JOB_STATUS_QUEUED, JOB_TYPE_PRECHECK, RECORDING_STATUS_QUEUED
- from lan_app.db import (
-+    create_recording,
-     create_job,
-     get_recording,
-     init_db,
-@@ -35,6 +36,7 @@ def _stub_enqueue(monkeypatch, cfg: AppSettings) -> None:
-         recording_id: str,
-         *,
-         job_type: str = JOB_TYPE_PRECHECK,
-+        force_reprocess: bool = False,
-         settings: AppSettings | None = None,
-     ) -> RecordingJob:
-         effective = settings or cfg
-@@ -191,3 +193,259 @@ def test_upload_queue_failure_rolls_back_recording(tmp_path: Path, monkeypatch):
-     assert total == 0
-     assert items == []
-     assert list(cfg.recordings_root.glob("trs_*")) == []
-+
-+
-+def test_find_matching_upload_recording_returns_existing_id(tmp_path: Path):
-+    cfg = _cfg(tmp_path)
-+    init_db(cfg)
-+    create_recording("rec-missing-raw", source="upload", source_filename="missing.mp3", settings=cfg)
-+    create_recording("rec-match", source="upload", source_filename="match.mp3", settings=cfg)
-+    raw_dir = cfg.recordings_root / "rec-match" / "raw"
-+    raw_dir.mkdir(parents=True, exist_ok=True)
-+    (raw_dir / "audio.mp3").write_bytes(b"same-audio")
-+    upload_path = tmp_path / "incoming.mp3"
-+    upload_path.write_bytes(b"same-audio")
-+
-+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) == "rec-match"
-+
-+
-+def test_find_matching_upload_recording_returns_none_for_missing_or_different_upload(
-+    tmp_path: Path,
-+):
-+    cfg = _cfg(tmp_path)
-+    init_db(cfg)
-+    upload_path = tmp_path / "incoming.mp3"
-+    upload_path.write_bytes(b"same-size")
-+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
-+
-+    create_recording("rec-other", source="upload", source_filename="other.mp3", settings=cfg)
-+    raw_dir = cfg.recordings_root / "rec-other" / "raw"
-+    raw_dir.mkdir(parents=True, exist_ok=True)
-+    (raw_dir / "audio.mp3").write_bytes(b"different")
-+
-+    missing_upload = tmp_path / "missing.mp3"
-+    assert uploads.find_matching_upload_recording(missing_upload, settings=cfg) is None
-+
-+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
-+
-+
-+def test_find_matching_upload_recording_returns_none_when_upload_stat_fails(
-+    tmp_path: Path,
-+    monkeypatch,
-+):
-+    cfg = _cfg(tmp_path)
-+    init_db(cfg)
-+    upload_path = tmp_path / "incoming.mp3"
-+    upload_path.write_bytes(b"abc")
-+
-+    real_stat = Path.stat
-+
-+    def _broken_stat(self: Path, *args, **kwargs):
-+        if self == upload_path:
-+            raise OSError("bad upload stat")
-+        return real_stat(self, *args, **kwargs)
-+
-+    monkeypatch.setattr(Path, "stat", _broken_stat)
-+
-+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
-+
-+
-+def test_find_matching_upload_recording_returns_none_for_directory_path(tmp_path: Path):
-+    cfg = _cfg(tmp_path)
-+    init_db(cfg)
-+    upload_dir = tmp_path / "incoming-dir"
-+    upload_dir.mkdir()
-+
-+    assert uploads.find_matching_upload_recording(upload_dir, settings=cfg) is None
-+
-+
-+def test_find_matching_upload_recording_skips_unreadable_existing_audio(
-+    tmp_path: Path,
-+    monkeypatch,
-+):
-+    cfg = _cfg(tmp_path)
-+    init_db(cfg)
-+    create_recording("rec-bad", source="upload", source_filename="bad.mp3", settings=cfg)
-+    raw_audio = cfg.recordings_root / "rec-bad" / "raw" / "audio.mp3"
-+    raw_audio.parent.mkdir(parents=True, exist_ok=True)
-+    raw_audio.write_bytes(b"abc")
-+    upload_path = tmp_path / "incoming.mp3"
-+    upload_path.write_bytes(b"abc")
-+
-+    real_sha256 = uploads._sha256_file
-+
-+    def _broken_sha256(path: Path) -> str:
-+        if path == raw_audio:
-+            raise OSError("bad raw audio")
-+        return real_sha256(path)
-+
-+    monkeypatch.setattr(uploads, "_sha256_file", _broken_sha256)
-+
-+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
-+
-+
-+def test_find_matching_upload_recording_skips_size_mismatch(tmp_path: Path):
-+    cfg = _cfg(tmp_path)
-+    init_db(cfg)
-+    create_recording("rec-size", source="upload", source_filename="size.mp3", settings=cfg)
-+    raw_audio = cfg.recordings_root / "rec-size" / "raw" / "audio.mp3"
-+    raw_audio.parent.mkdir(parents=True, exist_ok=True)
-+    raw_audio.write_bytes(b"abcd")
-+    upload_path = tmp_path / "incoming.mp3"
-+    upload_path.write_bytes(b"abc")
-+
-+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
-+
-+
-+def test_reupload_reuses_existing_recording_and_enqueues_force_reprocess(
+@@ -369,6 +369,66 @@ def test_reupload_reuses_existing_recording_and_enqueues_force_reprocess(
+     assert len(upload_dirs) == 1
+ 
+ 
++def test_upload_ignores_filesystem_match_without_recording_row(
 +    tmp_path: Path,
 +    monkeypatch,
 +    caplog,
@@ -287,7 +36,7 @@ index b884dfc..6e6b050 100644
 +    cfg = _cfg(tmp_path)
 +    monkeypatch.setattr(api, "_settings", cfg)
 +    init_db(cfg)
-+    caplog.set_level("INFO")
++    caplog.set_level("WARNING")
 +
 +    observed: list[dict[str, object]] = []
 +
@@ -313,121 +62,32 @@ index b884dfc..6e6b050 100644
 +
 +    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
 +
++    orphan_raw = cfg.recordings_root / "rec-orphan" / "raw" / "audio.mp3"
++    orphan_raw.parent.mkdir(parents=True, exist_ok=True)
++    orphan_raw.write_bytes(b"abc")
++
 +    client = TestClient(api.app)
-+    first = client.post(
++    response = client.post(
 +        "/api/uploads",
 +        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
 +    )
-+    assert first.status_code == 200
-+    first_payload = first.json()
++    assert response.status_code == 200
++    payload = response.json()
 +
-+    caplog.clear()
-+    second = client.post(
-+        "/api/uploads",
-+        files={"file": ("meeting-copy.mp3", b"abc", "audio/mpeg")},
-+    )
-+    assert second.status_code == 200
-+    second_payload = second.json()
-+
-+    assert second_payload["recording_id"] == first_payload["recording_id"]
-+    assert second_payload["captured_at"] == first_payload["captured_at"]
++    assert payload["recording_id"] != "rec-orphan"
 +    items, total = list_recordings(settings=cfg)
 +    assert total == 1
-+    assert items[0]["id"] == first_payload["recording_id"]
++    assert items[0]["id"] == payload["recording_id"]
 +    assert observed == [
 +        {
-+            "recording_id": first_payload["recording_id"],
++            "recording_id": payload["recording_id"],
 +            "job_type": JOB_TYPE_PRECHECK,
 +            "force_reprocess": False,
-+        },
-+        {
-+            "recording_id": first_payload["recording_id"],
-+            "job_type": JOB_TYPE_PRECHECK,
-+            "force_reprocess": True,
-+        },
++        }
 +    ]
-+    assert f"re-upload detected for {first_payload['recording_id']}" in caplog.text
-+    upload_dirs = sorted(cfg.recordings_root.glob("trs_*"))
-+    assert len(upload_dirs) == 1
++    assert "duplicate upload matched raw audio for rec-orphan" in caplog.text
 +
 +
-+def test_reupload_active_job_conflict_returns_409(tmp_path: Path, monkeypatch):
-+    cfg = _cfg(tmp_path)
-+    monkeypatch.setattr(api, "_settings", cfg)
-+    init_db(cfg)
-+
-+    def _fake_enqueue(
-+        recording_id: str,
-+        *,
-+        job_type: str = JOB_TYPE_PRECHECK,
-+        force_reprocess: bool = False,
-+        settings: AppSettings | None = None,
-+    ) -> RecordingJob:
-+        if force_reprocess:
-+            from lan_app.jobs import DuplicateRecordingJobError
-+
-+            raise DuplicateRecordingJobError(recording_id=recording_id, job_id="existing-job")
-+        return RecordingJob(
-+            job_id="job-first",
-+            recording_id=recording_id,
-+            job_type=job_type,
-+        )
-+
-+    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
-+
-+    client = TestClient(api.app)
-+    first = client.post(
-+        "/api/uploads",
-+        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
-+    )
-+    assert first.status_code == 200
-+
-+    second = client.post(
-+        "/api/uploads",
-+        files={"file": ("meeting-again.mp3", b"abc", "audio/mpeg")},
-+    )
-+    assert second.status_code == 409
-+    assert second.json()["detail"]["existing_job_id"] == "existing-job"
-+    items, total = list_recordings(settings=cfg)
-+    assert total == 1
-+    assert len(sorted(cfg.recordings_root.glob("trs_*"))) == 1
-+
-+
-+def test_reupload_queue_failure_returns_503(tmp_path: Path, monkeypatch):
-+    cfg = _cfg(tmp_path)
-+    monkeypatch.setattr(api, "_settings", cfg)
-+    init_db(cfg)
-+
-+    def _fake_enqueue(
-+        recording_id: str,
-+        *,
-+        job_type: str = JOB_TYPE_PRECHECK,
-+        force_reprocess: bool = False,
-+        settings: AppSettings | None = None,
-+    ) -> RecordingJob:
-+        if force_reprocess:
-+            raise RuntimeError("redis down")
-+        return RecordingJob(
-+            job_id="job-first",
-+            recording_id=recording_id,
-+            job_type=job_type,
-+        )
-+
-+    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
-+
-+    client = TestClient(api.app)
-+    first = client.post(
-+        "/api/uploads",
-+        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
-+    )
-+    assert first.status_code == 200
-+
-+    second = client.post(
-+        "/api/uploads",
-+        files={"file": ("meeting-again.mp3", b"abc", "audio/mpeg")},
-+    )
-+    assert second.status_code == 503
-+    assert second.json()["detail"] == "Queue unavailable: redis down"
-+    items, total = list_recordings(settings=cfg)
-+    assert total == 1
-+    assert len(sorted(cfg.recordings_root.glob("trs_*"))) == 1
+ def test_reupload_active_job_conflict_returns_409(tmp_path: Path, monkeypatch):
+     cfg = _cfg(tmp_path)
+     monkeypatch.setattr(api, "_settings", cfg)

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,34 +1,116 @@
 diff --git a/lan_app/api.py b/lan_app/api.py
-index 3cd053a..4842356 100644
+index 4842356..c27dcbc 100644
 --- a/lan_app/api.py
 +++ b/lan_app/api.py
-@@ -554,8 +554,16 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
-             settings=_settings,
+@@ -63,8 +63,8 @@ from .ops import RecordingDeleteError, delete_recording_with_artifacts
+ from .reaper import run_stuck_job_reaper_once
+ from .uploads import (
+     ALLOWED_UPLOAD_EXTENSIONS,
+-    find_matching_upload_recording,
+     infer_upload_capture_time,
++    iter_matching_upload_recordings,
+     safe_filename,
+     suffix_from_name,
+     write_upload_to_path,
+@@ -549,20 +549,22 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
+             file.filename or "",
+             upload_capture_timezone=_settings.upload_capture_tzinfo(),
          )
+-        matched_recording_id = find_matching_upload_recording(
++        matched_recording_id = None
++        existing = None
++        for candidate_recording_id in iter_matching_upload_recordings(
+             dest,
+             settings=_settings,
+-        )
+-        if matched_recording_id is not None:
+-            existing = get_recording(matched_recording_id, settings=_settings)
++        ):
++            existing = get_recording(candidate_recording_id, settings=_settings)
+             if existing is None:
+                 _logger.warning(
+                     "duplicate upload matched raw audio for %s but no recording row exists; treating upload as new",
+-                    matched_recording_id,
++                    candidate_recording_id,
+                 )
+-                matched_recording_id = None
+-            else:
+-                cleanup_uploaded_recording_dir = True
++                continue
++            matched_recording_id = candidate_recording_id
++            cleanup_uploaded_recording_dir = True
++            break
          if matched_recording_id is not None:
--            cleanup_uploaded_recording_dir = True
-             existing = get_recording(matched_recording_id, settings=_settings)
-+            if existing is None:
-+                _logger.warning(
-+                    "duplicate upload matched raw audio for %s but no recording row exists; treating upload as new",
-+                    matched_recording_id,
-+                )
-+                matched_recording_id = None
-+            else:
-+                cleanup_uploaded_recording_dir = True
-+        if matched_recording_id is not None:
              _logger.info(
                  "re-upload detected for %s, clearing derived artifacts for full reprocess",
-                 matched_recording_id,
+diff --git a/lan_app/uploads.py b/lan_app/uploads.py
+index a0d5f5a..a159292 100644
+--- a/lan_app/uploads.py
++++ b/lan_app/uploads.py
+@@ -3,6 +3,7 @@ from __future__ import annotations
+ from dataclasses import dataclass
+ from datetime import datetime, timezone
+ import hashlib
++from collections.abc import Iterator
+ from pathlib import Path
+ import re
+ import stat
+@@ -171,12 +172,25 @@ def find_matching_upload_recording(
+     *,
+     settings: AppSettings,
+ ) -> str | None:
++    for recording_id in iter_matching_upload_recordings(
++        upload_path,
++        settings=settings,
++    ):
++        return recording_id
++    return None
++
++
++def iter_matching_upload_recordings(
++    upload_path: Path,
++    *,
++    settings: AppSettings,
++) -> Iterator[str]:
+     try:
+         upload_stat = upload_path.stat()
+     except OSError:
+-        return None
++        return
+     if not stat.S_ISREG(upload_stat.st_mode):
+-        return None
++        return
+     upload_size = upload_stat.st_size
+     upload_digest = _sha256_file(upload_path)
+ 
+@@ -187,16 +201,16 @@ def find_matching_upload_recording(
+             if raw_audio.stat().st_size != upload_size:
+                 continue
+             if _sha256_file(raw_audio) == upload_digest:
+-                return raw_audio.parent.parent.name
++                yield raw_audio.parent.parent.name
+         except OSError:
+             continue
+-    return None
+ 
+ 
+ __all__ = [
+     "ALLOWED_UPLOAD_EXTENSIONS",
+     "CaptureTimeInference",
+     "find_matching_upload_recording",
++    "iter_matching_upload_recordings",
+     "infer_captured_at",
+     "infer_upload_capture_time",
+     "normalize_plaud_captured_at",
 diff --git a/tests/test_upload.py b/tests/test_upload.py
-index 6e6b050..162524e 100644
+index 162524e..b5d3d8c 100644
 --- a/tests/test_upload.py
 +++ b/tests/test_upload.py
-@@ -369,6 +369,66 @@ def test_reupload_reuses_existing_recording_and_enqueues_force_reprocess(
-     assert len(upload_dirs) == 1
+@@ -429,6 +429,71 @@ def test_upload_ignores_filesystem_match_without_recording_row(
+     assert "duplicate upload matched raw audio for rec-orphan" in caplog.text
  
  
-+def test_upload_ignores_filesystem_match_without_recording_row(
++def test_reupload_skips_orphan_match_and_reuses_persisted_recording(
 +    tmp_path: Path,
 +    monkeypatch,
 +    caplog,
@@ -62,9 +144,14 @@ index 6e6b050..162524e 100644
 +
 +    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
 +
-+    orphan_raw = cfg.recordings_root / "rec-orphan" / "raw" / "audio.mp3"
++    orphan_raw = cfg.recordings_root / "rec-aaa-orphan" / "raw" / "audio.mp3"
 +    orphan_raw.parent.mkdir(parents=True, exist_ok=True)
 +    orphan_raw.write_bytes(b"abc")
++
++    create_recording("rec-zzz-valid", source="upload", source_filename="valid.mp3", settings=cfg)
++    valid_raw = cfg.recordings_root / "rec-zzz-valid" / "raw" / "audio.mp3"
++    valid_raw.parent.mkdir(parents=True, exist_ok=True)
++    valid_raw.write_bytes(b"abc")
 +
 +    client = TestClient(api.app)
 +    response = client.post(
@@ -74,18 +161,18 @@ index 6e6b050..162524e 100644
 +    assert response.status_code == 200
 +    payload = response.json()
 +
-+    assert payload["recording_id"] != "rec-orphan"
++    assert payload["recording_id"] == "rec-zzz-valid"
 +    items, total = list_recordings(settings=cfg)
 +    assert total == 1
-+    assert items[0]["id"] == payload["recording_id"]
++    assert items[0]["id"] == "rec-zzz-valid"
 +    assert observed == [
 +        {
-+            "recording_id": payload["recording_id"],
++            "recording_id": "rec-zzz-valid",
 +            "job_type": JOB_TYPE_PRECHECK,
-+            "force_reprocess": False,
++            "force_reprocess": True,
 +        }
 +    ]
-+    assert "duplicate upload matched raw audio for rec-orphan" in caplog.text
++    assert "duplicate upload matched raw audio for rec-aaa-orphan" in caplog.text
 +
 +
  def test_reupload_active_job_conflict_returns_409(tmp_path: Path, monkeypatch):

--- a/artifacts/pr.patch
+++ b/artifacts/pr.patch
@@ -1,36 +1,433 @@
-diff --git a/lan_app/templates/partials/recording_inspector_body.html b/lan_app/templates/partials/recording_inspector_body.html
-index e8ace57..2d6f18b 100644
---- a/lan_app/templates/partials/recording_inspector_body.html
-+++ b/lan_app/templates/partials/recording_inspector_body.html
-@@ -2,7 +2,7 @@
-   id="recording-inspector-body"
-   {% if recording_inspector.auto_refresh_body %}
-   hx-get="{{ recording_inspector.body_url }}"
--  hx-trigger="load, every 2s"
-+  hx-trigger="every 2s"
-   hx-swap="outerHTML"
-   {% endif %}
- >
-diff --git a/tests/test_ui_routes.py b/tests/test_ui_routes.py
-index 1ee4711..9bca96d 100644
---- a/tests/test_ui_routes.py
-+++ b/tests/test_ui_routes.py
-@@ -4890,7 +4890,8 @@ def test_recording_detail_body_stops_polling_after_resummarize_finishes(
-     active_body = c.get("/ui/recordings/rec-rsum-ui-stop-poll-1/body?tab=summary")
-     assert active_body.status_code == 200
-     assert '/ui/recordings/rec-rsum-ui-stop-poll-1/body?tab=summary' in active_body.text
--    assert 'hx-trigger="load, every 2s"' in active_body.text
-+    assert 'hx-trigger="every 2s"' in active_body.text
-+    assert 'hx-trigger="load, every 2s"' not in active_body.text
+diff --git a/lan_app/api.py b/lan_app/api.py
+index dff90f7..3cd053a 100644
+--- a/lan_app/api.py
++++ b/lan_app/api.py
+@@ -63,6 +63,7 @@ from .ops import RecordingDeleteError, delete_recording_with_artifacts
+ from .reaper import run_stuck_job_reaper_once
+ from .uploads import (
+     ALLOWED_UPLOAD_EXTENSIONS,
++    find_matching_upload_recording,
+     infer_upload_capture_time,
+     safe_filename,
+     suffix_from_name,
+@@ -535,6 +536,7 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
+     raw_dir = recording_dir / "raw"
+     dest = raw_dir / f"audio{ext}"
+     completed = False
++    cleanup_uploaded_recording_dir = False
+     recording_created = False
  
-     monkeypatch.setattr(
-         ui_routes,
-@@ -4900,7 +4901,7 @@ def test_recording_detail_body_stops_polling_after_resummarize_finishes(
+     try:
+@@ -547,6 +549,42 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
+             file.filename or "",
+             upload_capture_timezone=_settings.upload_capture_tzinfo(),
+         )
++        matched_recording_id = find_matching_upload_recording(
++            dest,
++            settings=_settings,
++        )
++        if matched_recording_id is not None:
++            cleanup_uploaded_recording_dir = True
++            existing = get_recording(matched_recording_id, settings=_settings)
++            _logger.info(
++                "re-upload detected for %s, clearing derived artifacts for full reprocess",
++                matched_recording_id,
++            )
++            try:
++                job = enqueue_recording_job(
++                    matched_recording_id,
++                    job_type=JOB_TYPE_PRECHECK,
++                    force_reprocess=True,
++                    settings=_settings,
++                )
++            except DuplicateRecordingJobError as exc:
++                raise HTTPException(
++                    status_code=409,
++                    detail={
++                        "message": "A precheck job is already queued or started for this recording.",
++                        "existing_job_id": exc.job_id,
++                    },
++                )
++            except Exception as exc:
++                raise HTTPException(status_code=503, detail=f"Queue unavailable: {exc}")
++
++            completed = True
++            return {
++                "recording_id": matched_recording_id,
++                "job_id": job.job_id,
++                "captured_at": str(existing["captured_at"]),
++                "bytes_written": bytes_written,
++            }
+         create_recording(
+             recording_id,
+             source="upload",
+@@ -599,7 +637,7 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
+         raise HTTPException(status_code=503, detail=f"Upload failed: {exc}")
+     finally:
+         await file.close()
+-        if not completed and recording_dir.exists():
++        if (not completed or cleanup_uploaded_recording_dir) and recording_dir.exists():
+             shutil.rmtree(recording_dir, ignore_errors=True)
+         if not completed and recording_created:
+             with suppress(Exception):
+diff --git a/lan_app/uploads.py b/lan_app/uploads.py
+index 3e0c50c..a0d5f5a 100644
+--- a/lan_app/uploads.py
++++ b/lan_app/uploads.py
+@@ -2,11 +2,15 @@ from __future__ import annotations
  
-     settled_body = c.get("/ui/recordings/rec-rsum-ui-stop-poll-1/body?tab=summary")
-     assert settled_body.status_code == 200
--    assert 'hx-trigger="load, every 2s"' not in settled_body.text
-+    assert 'hx-trigger="every 2s"' not in settled_body.text
-     assert '/ui/recordings/rec-rsum-ui-stop-poll-1/body?tab=summary' not in settled_body.text
+ from dataclasses import dataclass
+ from datetime import datetime, timezone
++import hashlib
+ from pathlib import Path
+ import re
++import stat
+ from typing import BinaryIO
+ from zoneinfo import ZoneInfo
+ 
++from .config import AppSettings
++
+ ALLOWED_UPLOAD_EXTENSIONS = {
+     ".mp3",
+     ".wav",
+@@ -151,9 +155,48 @@ def write_upload_to_path(upload, dest: Path, *, max_bytes: int | None) -> int:
+     return bytes_written
  
  
++def _sha256_file(path: Path) -> str:
++    digest = hashlib.sha256()
++    with path.open("rb") as fh:
++        while True:
++            chunk = fh.read(_COPY_CHUNK_SIZE)
++            if not chunk:
++                break
++            digest.update(chunk)
++    return digest.hexdigest()
++
++
++def find_matching_upload_recording(
++    upload_path: Path,
++    *,
++    settings: AppSettings,
++) -> str | None:
++    try:
++        upload_stat = upload_path.stat()
++    except OSError:
++        return None
++    if not stat.S_ISREG(upload_stat.st_mode):
++        return None
++    upload_size = upload_stat.st_size
++    upload_digest = _sha256_file(upload_path)
++
++    for raw_audio in sorted(settings.recordings_root.glob("*/raw/audio.*")):
++        if raw_audio == upload_path:
++            continue
++        try:
++            if raw_audio.stat().st_size != upload_size:
++                continue
++            if _sha256_file(raw_audio) == upload_digest:
++                return raw_audio.parent.parent.name
++        except OSError:
++            continue
++    return None
++
++
+ __all__ = [
+     "ALLOWED_UPLOAD_EXTENSIONS",
+     "CaptureTimeInference",
++    "find_matching_upload_recording",
+     "infer_captured_at",
+     "infer_upload_capture_time",
+     "normalize_plaud_captured_at",
+diff --git a/tasks/QUEUE.md b/tasks/QUEUE.md
+index 22541fd..928d8f3 100644
+--- a/tasks/QUEUE.md
++++ b/tasks/QUEUE.md
+@@ -776,6 +776,6 @@ Queue (in order)
+ - Depends on: PR-LLM-INLINE-EXECUTION-01
+ 
+ 155) PR-REUPLOAD-REPROCESS-01: Force full reprocess when re-uploading an existing audio file
+-- Status: TODO
++- Status: DONE
+ - Tasks file: tasks/PR-REUPLOAD-REPROCESS-01.md
+ - Depends on: PR-FORCE-REPROCESS-01
+diff --git a/tests/test_upload.py b/tests/test_upload.py
+index b884dfc..6e6b050 100644
+--- a/tests/test_upload.py
++++ b/tests/test_upload.py
+@@ -10,6 +10,7 @@ from lan_app import api, uploads
+ from lan_app.config import AppSettings
+ from lan_app.constants import JOB_STATUS_QUEUED, JOB_TYPE_PRECHECK, RECORDING_STATUS_QUEUED
+ from lan_app.db import (
++    create_recording,
+     create_job,
+     get_recording,
+     init_db,
+@@ -35,6 +36,7 @@ def _stub_enqueue(monkeypatch, cfg: AppSettings) -> None:
+         recording_id: str,
+         *,
+         job_type: str = JOB_TYPE_PRECHECK,
++        force_reprocess: bool = False,
+         settings: AppSettings | None = None,
+     ) -> RecordingJob:
+         effective = settings or cfg
+@@ -191,3 +193,259 @@ def test_upload_queue_failure_rolls_back_recording(tmp_path: Path, monkeypatch):
+     assert total == 0
+     assert items == []
+     assert list(cfg.recordings_root.glob("trs_*")) == []
++
++
++def test_find_matching_upload_recording_returns_existing_id(tmp_path: Path):
++    cfg = _cfg(tmp_path)
++    init_db(cfg)
++    create_recording("rec-missing-raw", source="upload", source_filename="missing.mp3", settings=cfg)
++    create_recording("rec-match", source="upload", source_filename="match.mp3", settings=cfg)
++    raw_dir = cfg.recordings_root / "rec-match" / "raw"
++    raw_dir.mkdir(parents=True, exist_ok=True)
++    (raw_dir / "audio.mp3").write_bytes(b"same-audio")
++    upload_path = tmp_path / "incoming.mp3"
++    upload_path.write_bytes(b"same-audio")
++
++    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) == "rec-match"
++
++
++def test_find_matching_upload_recording_returns_none_for_missing_or_different_upload(
++    tmp_path: Path,
++):
++    cfg = _cfg(tmp_path)
++    init_db(cfg)
++    upload_path = tmp_path / "incoming.mp3"
++    upload_path.write_bytes(b"same-size")
++    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
++
++    create_recording("rec-other", source="upload", source_filename="other.mp3", settings=cfg)
++    raw_dir = cfg.recordings_root / "rec-other" / "raw"
++    raw_dir.mkdir(parents=True, exist_ok=True)
++    (raw_dir / "audio.mp3").write_bytes(b"different")
++
++    missing_upload = tmp_path / "missing.mp3"
++    assert uploads.find_matching_upload_recording(missing_upload, settings=cfg) is None
++
++    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
++
++
++def test_find_matching_upload_recording_returns_none_when_upload_stat_fails(
++    tmp_path: Path,
++    monkeypatch,
++):
++    cfg = _cfg(tmp_path)
++    init_db(cfg)
++    upload_path = tmp_path / "incoming.mp3"
++    upload_path.write_bytes(b"abc")
++
++    real_stat = Path.stat
++
++    def _broken_stat(self: Path, *args, **kwargs):
++        if self == upload_path:
++            raise OSError("bad upload stat")
++        return real_stat(self, *args, **kwargs)
++
++    monkeypatch.setattr(Path, "stat", _broken_stat)
++
++    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
++
++
++def test_find_matching_upload_recording_returns_none_for_directory_path(tmp_path: Path):
++    cfg = _cfg(tmp_path)
++    init_db(cfg)
++    upload_dir = tmp_path / "incoming-dir"
++    upload_dir.mkdir()
++
++    assert uploads.find_matching_upload_recording(upload_dir, settings=cfg) is None
++
++
++def test_find_matching_upload_recording_skips_unreadable_existing_audio(
++    tmp_path: Path,
++    monkeypatch,
++):
++    cfg = _cfg(tmp_path)
++    init_db(cfg)
++    create_recording("rec-bad", source="upload", source_filename="bad.mp3", settings=cfg)
++    raw_audio = cfg.recordings_root / "rec-bad" / "raw" / "audio.mp3"
++    raw_audio.parent.mkdir(parents=True, exist_ok=True)
++    raw_audio.write_bytes(b"abc")
++    upload_path = tmp_path / "incoming.mp3"
++    upload_path.write_bytes(b"abc")
++
++    real_sha256 = uploads._sha256_file
++
++    def _broken_sha256(path: Path) -> str:
++        if path == raw_audio:
++            raise OSError("bad raw audio")
++        return real_sha256(path)
++
++    monkeypatch.setattr(uploads, "_sha256_file", _broken_sha256)
++
++    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
++
++
++def test_find_matching_upload_recording_skips_size_mismatch(tmp_path: Path):
++    cfg = _cfg(tmp_path)
++    init_db(cfg)
++    create_recording("rec-size", source="upload", source_filename="size.mp3", settings=cfg)
++    raw_audio = cfg.recordings_root / "rec-size" / "raw" / "audio.mp3"
++    raw_audio.parent.mkdir(parents=True, exist_ok=True)
++    raw_audio.write_bytes(b"abcd")
++    upload_path = tmp_path / "incoming.mp3"
++    upload_path.write_bytes(b"abc")
++
++    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
++
++
++def test_reupload_reuses_existing_recording_and_enqueues_force_reprocess(
++    tmp_path: Path,
++    monkeypatch,
++    caplog,
++):
++    cfg = _cfg(tmp_path)
++    monkeypatch.setattr(api, "_settings", cfg)
++    init_db(cfg)
++    caplog.set_level("INFO")
++
++    observed: list[dict[str, object]] = []
++
++    def _fake_enqueue(
++        recording_id: str,
++        *,
++        job_type: str = JOB_TYPE_PRECHECK,
++        force_reprocess: bool = False,
++        settings: AppSettings | None = None,
++    ) -> RecordingJob:
++        observed.append(
++            {
++                "recording_id": recording_id,
++                "job_type": job_type,
++                "force_reprocess": force_reprocess,
++            }
++        )
++        return RecordingJob(
++            job_id=f"job-{len(observed)}",
++            recording_id=recording_id,
++            job_type=job_type,
++        )
++
++    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
++
++    client = TestClient(api.app)
++    first = client.post(
++        "/api/uploads",
++        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
++    )
++    assert first.status_code == 200
++    first_payload = first.json()
++
++    caplog.clear()
++    second = client.post(
++        "/api/uploads",
++        files={"file": ("meeting-copy.mp3", b"abc", "audio/mpeg")},
++    )
++    assert second.status_code == 200
++    second_payload = second.json()
++
++    assert second_payload["recording_id"] == first_payload["recording_id"]
++    assert second_payload["captured_at"] == first_payload["captured_at"]
++    items, total = list_recordings(settings=cfg)
++    assert total == 1
++    assert items[0]["id"] == first_payload["recording_id"]
++    assert observed == [
++        {
++            "recording_id": first_payload["recording_id"],
++            "job_type": JOB_TYPE_PRECHECK,
++            "force_reprocess": False,
++        },
++        {
++            "recording_id": first_payload["recording_id"],
++            "job_type": JOB_TYPE_PRECHECK,
++            "force_reprocess": True,
++        },
++    ]
++    assert f"re-upload detected for {first_payload['recording_id']}" in caplog.text
++    upload_dirs = sorted(cfg.recordings_root.glob("trs_*"))
++    assert len(upload_dirs) == 1
++
++
++def test_reupload_active_job_conflict_returns_409(tmp_path: Path, monkeypatch):
++    cfg = _cfg(tmp_path)
++    monkeypatch.setattr(api, "_settings", cfg)
++    init_db(cfg)
++
++    def _fake_enqueue(
++        recording_id: str,
++        *,
++        job_type: str = JOB_TYPE_PRECHECK,
++        force_reprocess: bool = False,
++        settings: AppSettings | None = None,
++    ) -> RecordingJob:
++        if force_reprocess:
++            from lan_app.jobs import DuplicateRecordingJobError
++
++            raise DuplicateRecordingJobError(recording_id=recording_id, job_id="existing-job")
++        return RecordingJob(
++            job_id="job-first",
++            recording_id=recording_id,
++            job_type=job_type,
++        )
++
++    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
++
++    client = TestClient(api.app)
++    first = client.post(
++        "/api/uploads",
++        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
++    )
++    assert first.status_code == 200
++
++    second = client.post(
++        "/api/uploads",
++        files={"file": ("meeting-again.mp3", b"abc", "audio/mpeg")},
++    )
++    assert second.status_code == 409
++    assert second.json()["detail"]["existing_job_id"] == "existing-job"
++    items, total = list_recordings(settings=cfg)
++    assert total == 1
++    assert len(sorted(cfg.recordings_root.glob("trs_*"))) == 1
++
++
++def test_reupload_queue_failure_returns_503(tmp_path: Path, monkeypatch):
++    cfg = _cfg(tmp_path)
++    monkeypatch.setattr(api, "_settings", cfg)
++    init_db(cfg)
++
++    def _fake_enqueue(
++        recording_id: str,
++        *,
++        job_type: str = JOB_TYPE_PRECHECK,
++        force_reprocess: bool = False,
++        settings: AppSettings | None = None,
++    ) -> RecordingJob:
++        if force_reprocess:
++            raise RuntimeError("redis down")
++        return RecordingJob(
++            job_id="job-first",
++            recording_id=recording_id,
++            job_type=job_type,
++        )
++
++    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
++
++    client = TestClient(api.app)
++    first = client.post(
++        "/api/uploads",
++        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
++    )
++    assert first.status_code == 200
++
++    second = client.post(
++        "/api/uploads",
++        files={"file": ("meeting-again.mp3", b"abc", "audio/mpeg")},
++    )
++    assert second.status_code == 503
++    assert second.json()["detail"] == "Queue unavailable: redis down"
++    items, total = list_recordings(settings=cfg)
++    assert total == 1
++    assert len(sorted(cfg.recordings_root.glob("trs_*"))) == 1

--- a/lan_app/api.py
+++ b/lan_app/api.py
@@ -63,8 +63,8 @@ from .ops import RecordingDeleteError, delete_recording_with_artifacts
 from .reaper import run_stuck_job_reaper_once
 from .uploads import (
     ALLOWED_UPLOAD_EXTENSIONS,
-    find_matching_upload_recording,
     infer_upload_capture_time,
+    iter_matching_upload_recordings,
     safe_filename,
     suffix_from_name,
     write_upload_to_path,
@@ -549,20 +549,22 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
             file.filename or "",
             upload_capture_timezone=_settings.upload_capture_tzinfo(),
         )
-        matched_recording_id = find_matching_upload_recording(
+        matched_recording_id = None
+        existing = None
+        for candidate_recording_id in iter_matching_upload_recordings(
             dest,
             settings=_settings,
-        )
-        if matched_recording_id is not None:
-            existing = get_recording(matched_recording_id, settings=_settings)
+        ):
+            existing = get_recording(candidate_recording_id, settings=_settings)
             if existing is None:
                 _logger.warning(
                     "duplicate upload matched raw audio for %s but no recording row exists; treating upload as new",
-                    matched_recording_id,
+                    candidate_recording_id,
                 )
-                matched_recording_id = None
-            else:
-                cleanup_uploaded_recording_dir = True
+                continue
+            matched_recording_id = candidate_recording_id
+            cleanup_uploaded_recording_dir = True
+            break
         if matched_recording_id is not None:
             _logger.info(
                 "re-upload detected for %s, clearing derived artifacts for full reprocess",

--- a/lan_app/api.py
+++ b/lan_app/api.py
@@ -63,6 +63,7 @@ from .ops import RecordingDeleteError, delete_recording_with_artifacts
 from .reaper import run_stuck_job_reaper_once
 from .uploads import (
     ALLOWED_UPLOAD_EXTENSIONS,
+    find_matching_upload_recording,
     infer_upload_capture_time,
     safe_filename,
     suffix_from_name,
@@ -535,6 +536,7 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
     raw_dir = recording_dir / "raw"
     dest = raw_dir / f"audio{ext}"
     completed = False
+    cleanup_uploaded_recording_dir = False
     recording_created = False
 
     try:
@@ -547,6 +549,42 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
             file.filename or "",
             upload_capture_timezone=_settings.upload_capture_tzinfo(),
         )
+        matched_recording_id = find_matching_upload_recording(
+            dest,
+            settings=_settings,
+        )
+        if matched_recording_id is not None:
+            cleanup_uploaded_recording_dir = True
+            existing = get_recording(matched_recording_id, settings=_settings)
+            _logger.info(
+                "re-upload detected for %s, clearing derived artifacts for full reprocess",
+                matched_recording_id,
+            )
+            try:
+                job = enqueue_recording_job(
+                    matched_recording_id,
+                    job_type=JOB_TYPE_PRECHECK,
+                    force_reprocess=True,
+                    settings=_settings,
+                )
+            except DuplicateRecordingJobError as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "message": "A precheck job is already queued or started for this recording.",
+                        "existing_job_id": exc.job_id,
+                    },
+                )
+            except Exception as exc:
+                raise HTTPException(status_code=503, detail=f"Queue unavailable: {exc}")
+
+            completed = True
+            return {
+                "recording_id": matched_recording_id,
+                "job_id": job.job_id,
+                "captured_at": str(existing["captured_at"]),
+                "bytes_written": bytes_written,
+            }
         create_recording(
             recording_id,
             source="upload",
@@ -599,7 +637,7 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
         raise HTTPException(status_code=503, detail=f"Upload failed: {exc}")
     finally:
         await file.close()
-        if not completed and recording_dir.exists():
+        if (not completed or cleanup_uploaded_recording_dir) and recording_dir.exists():
             shutil.rmtree(recording_dir, ignore_errors=True)
         if not completed and recording_created:
             with suppress(Exception):

--- a/lan_app/api.py
+++ b/lan_app/api.py
@@ -554,8 +554,16 @@ async def api_upload_file(file: UploadFile = File(...)) -> dict[str, object]:
             settings=_settings,
         )
         if matched_recording_id is not None:
-            cleanup_uploaded_recording_dir = True
             existing = get_recording(matched_recording_id, settings=_settings)
+            if existing is None:
+                _logger.warning(
+                    "duplicate upload matched raw audio for %s but no recording row exists; treating upload as new",
+                    matched_recording_id,
+                )
+                matched_recording_id = None
+            else:
+                cleanup_uploaded_recording_dir = True
+        if matched_recording_id is not None:
             _logger.info(
                 "re-upload detected for %s, clearing derived artifacts for full reprocess",
                 matched_recording_id,

--- a/lan_app/uploads.py
+++ b/lan_app/uploads.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import hashlib
 from pathlib import Path
 import re
+import stat
 from typing import BinaryIO
 from zoneinfo import ZoneInfo
+
+from .config import AppSettings
 
 ALLOWED_UPLOAD_EXTENSIONS = {
     ".mp3",
@@ -151,9 +155,48 @@ def write_upload_to_path(upload, dest: Path, *, max_bytes: int | None) -> int:
     return bytes_written
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        while True:
+            chunk = fh.read(_COPY_CHUNK_SIZE)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def find_matching_upload_recording(
+    upload_path: Path,
+    *,
+    settings: AppSettings,
+) -> str | None:
+    try:
+        upload_stat = upload_path.stat()
+    except OSError:
+        return None
+    if not stat.S_ISREG(upload_stat.st_mode):
+        return None
+    upload_size = upload_stat.st_size
+    upload_digest = _sha256_file(upload_path)
+
+    for raw_audio in sorted(settings.recordings_root.glob("*/raw/audio.*")):
+        if raw_audio == upload_path:
+            continue
+        try:
+            if raw_audio.stat().st_size != upload_size:
+                continue
+            if _sha256_file(raw_audio) == upload_digest:
+                return raw_audio.parent.parent.name
+        except OSError:
+            continue
+    return None
+
+
 __all__ = [
     "ALLOWED_UPLOAD_EXTENSIONS",
     "CaptureTimeInference",
+    "find_matching_upload_recording",
     "infer_captured_at",
     "infer_upload_capture_time",
     "normalize_plaud_captured_at",

--- a/lan_app/uploads.py
+++ b/lan_app/uploads.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
+from collections.abc import Iterator
 from pathlib import Path
 import re
 import stat
@@ -171,12 +172,25 @@ def find_matching_upload_recording(
     *,
     settings: AppSettings,
 ) -> str | None:
+    for recording_id in iter_matching_upload_recordings(
+        upload_path,
+        settings=settings,
+    ):
+        return recording_id
+    return None
+
+
+def iter_matching_upload_recordings(
+    upload_path: Path,
+    *,
+    settings: AppSettings,
+) -> Iterator[str]:
     try:
         upload_stat = upload_path.stat()
     except OSError:
-        return None
+        return
     if not stat.S_ISREG(upload_stat.st_mode):
-        return None
+        return
     upload_size = upload_stat.st_size
     upload_digest = _sha256_file(upload_path)
 
@@ -187,16 +201,16 @@ def find_matching_upload_recording(
             if raw_audio.stat().st_size != upload_size:
                 continue
             if _sha256_file(raw_audio) == upload_digest:
-                return raw_audio.parent.parent.name
+                yield raw_audio.parent.parent.name
         except OSError:
             continue
-    return None
 
 
 __all__ = [
     "ALLOWED_UPLOAD_EXTENSIONS",
     "CaptureTimeInference",
     "find_matching_upload_recording",
+    "iter_matching_upload_recordings",
     "infer_captured_at",
     "infer_upload_capture_time",
     "normalize_plaud_captured_at",

--- a/tasks/QUEUE.md
+++ b/tasks/QUEUE.md
@@ -776,6 +776,6 @@ Queue (in order)
 - Depends on: PR-LLM-INLINE-EXECUTION-01
 
 155) PR-REUPLOAD-REPROCESS-01: Force full reprocess when re-uploading an existing audio file
-- Status: TODO
+- Status: DONE
 - Tasks file: tasks/PR-REUPLOAD-REPROCESS-01.md
 - Depends on: PR-FORCE-REPROCESS-01

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -429,6 +429,71 @@ def test_upload_ignores_filesystem_match_without_recording_row(
     assert "duplicate upload matched raw audio for rec-orphan" in caplog.text
 
 
+def test_reupload_skips_orphan_match_and_reuses_persisted_recording(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+):
+    cfg = _cfg(tmp_path)
+    monkeypatch.setattr(api, "_settings", cfg)
+    init_db(cfg)
+    caplog.set_level("WARNING")
+
+    observed: list[dict[str, object]] = []
+
+    def _fake_enqueue(
+        recording_id: str,
+        *,
+        job_type: str = JOB_TYPE_PRECHECK,
+        force_reprocess: bool = False,
+        settings: AppSettings | None = None,
+    ) -> RecordingJob:
+        observed.append(
+            {
+                "recording_id": recording_id,
+                "job_type": job_type,
+                "force_reprocess": force_reprocess,
+            }
+        )
+        return RecordingJob(
+            job_id=f"job-{len(observed)}",
+            recording_id=recording_id,
+            job_type=job_type,
+        )
+
+    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
+
+    orphan_raw = cfg.recordings_root / "rec-aaa-orphan" / "raw" / "audio.mp3"
+    orphan_raw.parent.mkdir(parents=True, exist_ok=True)
+    orphan_raw.write_bytes(b"abc")
+
+    create_recording("rec-zzz-valid", source="upload", source_filename="valid.mp3", settings=cfg)
+    valid_raw = cfg.recordings_root / "rec-zzz-valid" / "raw" / "audio.mp3"
+    valid_raw.parent.mkdir(parents=True, exist_ok=True)
+    valid_raw.write_bytes(b"abc")
+
+    client = TestClient(api.app)
+    response = client.post(
+        "/api/uploads",
+        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["recording_id"] == "rec-zzz-valid"
+    items, total = list_recordings(settings=cfg)
+    assert total == 1
+    assert items[0]["id"] == "rec-zzz-valid"
+    assert observed == [
+        {
+            "recording_id": "rec-zzz-valid",
+            "job_type": JOB_TYPE_PRECHECK,
+            "force_reprocess": True,
+        }
+    ]
+    assert "duplicate upload matched raw audio for rec-aaa-orphan" in caplog.text
+
+
 def test_reupload_active_job_conflict_returns_409(tmp_path: Path, monkeypatch):
     cfg = _cfg(tmp_path)
     monkeypatch.setattr(api, "_settings", cfg)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -369,6 +369,66 @@ def test_reupload_reuses_existing_recording_and_enqueues_force_reprocess(
     assert len(upload_dirs) == 1
 
 
+def test_upload_ignores_filesystem_match_without_recording_row(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+):
+    cfg = _cfg(tmp_path)
+    monkeypatch.setattr(api, "_settings", cfg)
+    init_db(cfg)
+    caplog.set_level("WARNING")
+
+    observed: list[dict[str, object]] = []
+
+    def _fake_enqueue(
+        recording_id: str,
+        *,
+        job_type: str = JOB_TYPE_PRECHECK,
+        force_reprocess: bool = False,
+        settings: AppSettings | None = None,
+    ) -> RecordingJob:
+        observed.append(
+            {
+                "recording_id": recording_id,
+                "job_type": job_type,
+                "force_reprocess": force_reprocess,
+            }
+        )
+        return RecordingJob(
+            job_id=f"job-{len(observed)}",
+            recording_id=recording_id,
+            job_type=job_type,
+        )
+
+    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
+
+    orphan_raw = cfg.recordings_root / "rec-orphan" / "raw" / "audio.mp3"
+    orphan_raw.parent.mkdir(parents=True, exist_ok=True)
+    orphan_raw.write_bytes(b"abc")
+
+    client = TestClient(api.app)
+    response = client.post(
+        "/api/uploads",
+        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["recording_id"] != "rec-orphan"
+    items, total = list_recordings(settings=cfg)
+    assert total == 1
+    assert items[0]["id"] == payload["recording_id"]
+    assert observed == [
+        {
+            "recording_id": payload["recording_id"],
+            "job_type": JOB_TYPE_PRECHECK,
+            "force_reprocess": False,
+        }
+    ]
+    assert "duplicate upload matched raw audio for rec-orphan" in caplog.text
+
+
 def test_reupload_active_job_conflict_returns_409(tmp_path: Path, monkeypatch):
     cfg = _cfg(tmp_path)
     monkeypatch.setattr(api, "_settings", cfg)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -10,6 +10,7 @@ from lan_app import api, uploads
 from lan_app.config import AppSettings
 from lan_app.constants import JOB_STATUS_QUEUED, JOB_TYPE_PRECHECK, RECORDING_STATUS_QUEUED
 from lan_app.db import (
+    create_recording,
     create_job,
     get_recording,
     init_db,
@@ -35,6 +36,7 @@ def _stub_enqueue(monkeypatch, cfg: AppSettings) -> None:
         recording_id: str,
         *,
         job_type: str = JOB_TYPE_PRECHECK,
+        force_reprocess: bool = False,
         settings: AppSettings | None = None,
     ) -> RecordingJob:
         effective = settings or cfg
@@ -191,3 +193,259 @@ def test_upload_queue_failure_rolls_back_recording(tmp_path: Path, monkeypatch):
     assert total == 0
     assert items == []
     assert list(cfg.recordings_root.glob("trs_*")) == []
+
+
+def test_find_matching_upload_recording_returns_existing_id(tmp_path: Path):
+    cfg = _cfg(tmp_path)
+    init_db(cfg)
+    create_recording("rec-missing-raw", source="upload", source_filename="missing.mp3", settings=cfg)
+    create_recording("rec-match", source="upload", source_filename="match.mp3", settings=cfg)
+    raw_dir = cfg.recordings_root / "rec-match" / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "audio.mp3").write_bytes(b"same-audio")
+    upload_path = tmp_path / "incoming.mp3"
+    upload_path.write_bytes(b"same-audio")
+
+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) == "rec-match"
+
+
+def test_find_matching_upload_recording_returns_none_for_missing_or_different_upload(
+    tmp_path: Path,
+):
+    cfg = _cfg(tmp_path)
+    init_db(cfg)
+    upload_path = tmp_path / "incoming.mp3"
+    upload_path.write_bytes(b"same-size")
+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
+
+    create_recording("rec-other", source="upload", source_filename="other.mp3", settings=cfg)
+    raw_dir = cfg.recordings_root / "rec-other" / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "audio.mp3").write_bytes(b"different")
+
+    missing_upload = tmp_path / "missing.mp3"
+    assert uploads.find_matching_upload_recording(missing_upload, settings=cfg) is None
+
+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
+
+
+def test_find_matching_upload_recording_returns_none_when_upload_stat_fails(
+    tmp_path: Path,
+    monkeypatch,
+):
+    cfg = _cfg(tmp_path)
+    init_db(cfg)
+    upload_path = tmp_path / "incoming.mp3"
+    upload_path.write_bytes(b"abc")
+
+    real_stat = Path.stat
+
+    def _broken_stat(self: Path, *args, **kwargs):
+        if self == upload_path:
+            raise OSError("bad upload stat")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _broken_stat)
+
+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
+
+
+def test_find_matching_upload_recording_returns_none_for_directory_path(tmp_path: Path):
+    cfg = _cfg(tmp_path)
+    init_db(cfg)
+    upload_dir = tmp_path / "incoming-dir"
+    upload_dir.mkdir()
+
+    assert uploads.find_matching_upload_recording(upload_dir, settings=cfg) is None
+
+
+def test_find_matching_upload_recording_skips_unreadable_existing_audio(
+    tmp_path: Path,
+    monkeypatch,
+):
+    cfg = _cfg(tmp_path)
+    init_db(cfg)
+    create_recording("rec-bad", source="upload", source_filename="bad.mp3", settings=cfg)
+    raw_audio = cfg.recordings_root / "rec-bad" / "raw" / "audio.mp3"
+    raw_audio.parent.mkdir(parents=True, exist_ok=True)
+    raw_audio.write_bytes(b"abc")
+    upload_path = tmp_path / "incoming.mp3"
+    upload_path.write_bytes(b"abc")
+
+    real_sha256 = uploads._sha256_file
+
+    def _broken_sha256(path: Path) -> str:
+        if path == raw_audio:
+            raise OSError("bad raw audio")
+        return real_sha256(path)
+
+    monkeypatch.setattr(uploads, "_sha256_file", _broken_sha256)
+
+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
+
+
+def test_find_matching_upload_recording_skips_size_mismatch(tmp_path: Path):
+    cfg = _cfg(tmp_path)
+    init_db(cfg)
+    create_recording("rec-size", source="upload", source_filename="size.mp3", settings=cfg)
+    raw_audio = cfg.recordings_root / "rec-size" / "raw" / "audio.mp3"
+    raw_audio.parent.mkdir(parents=True, exist_ok=True)
+    raw_audio.write_bytes(b"abcd")
+    upload_path = tmp_path / "incoming.mp3"
+    upload_path.write_bytes(b"abc")
+
+    assert uploads.find_matching_upload_recording(upload_path, settings=cfg) is None
+
+
+def test_reupload_reuses_existing_recording_and_enqueues_force_reprocess(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+):
+    cfg = _cfg(tmp_path)
+    monkeypatch.setattr(api, "_settings", cfg)
+    init_db(cfg)
+    caplog.set_level("INFO")
+
+    observed: list[dict[str, object]] = []
+
+    def _fake_enqueue(
+        recording_id: str,
+        *,
+        job_type: str = JOB_TYPE_PRECHECK,
+        force_reprocess: bool = False,
+        settings: AppSettings | None = None,
+    ) -> RecordingJob:
+        observed.append(
+            {
+                "recording_id": recording_id,
+                "job_type": job_type,
+                "force_reprocess": force_reprocess,
+            }
+        )
+        return RecordingJob(
+            job_id=f"job-{len(observed)}",
+            recording_id=recording_id,
+            job_type=job_type,
+        )
+
+    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
+
+    client = TestClient(api.app)
+    first = client.post(
+        "/api/uploads",
+        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
+    )
+    assert first.status_code == 200
+    first_payload = first.json()
+
+    caplog.clear()
+    second = client.post(
+        "/api/uploads",
+        files={"file": ("meeting-copy.mp3", b"abc", "audio/mpeg")},
+    )
+    assert second.status_code == 200
+    second_payload = second.json()
+
+    assert second_payload["recording_id"] == first_payload["recording_id"]
+    assert second_payload["captured_at"] == first_payload["captured_at"]
+    items, total = list_recordings(settings=cfg)
+    assert total == 1
+    assert items[0]["id"] == first_payload["recording_id"]
+    assert observed == [
+        {
+            "recording_id": first_payload["recording_id"],
+            "job_type": JOB_TYPE_PRECHECK,
+            "force_reprocess": False,
+        },
+        {
+            "recording_id": first_payload["recording_id"],
+            "job_type": JOB_TYPE_PRECHECK,
+            "force_reprocess": True,
+        },
+    ]
+    assert f"re-upload detected for {first_payload['recording_id']}" in caplog.text
+    upload_dirs = sorted(cfg.recordings_root.glob("trs_*"))
+    assert len(upload_dirs) == 1
+
+
+def test_reupload_active_job_conflict_returns_409(tmp_path: Path, monkeypatch):
+    cfg = _cfg(tmp_path)
+    monkeypatch.setattr(api, "_settings", cfg)
+    init_db(cfg)
+
+    def _fake_enqueue(
+        recording_id: str,
+        *,
+        job_type: str = JOB_TYPE_PRECHECK,
+        force_reprocess: bool = False,
+        settings: AppSettings | None = None,
+    ) -> RecordingJob:
+        if force_reprocess:
+            from lan_app.jobs import DuplicateRecordingJobError
+
+            raise DuplicateRecordingJobError(recording_id=recording_id, job_id="existing-job")
+        return RecordingJob(
+            job_id="job-first",
+            recording_id=recording_id,
+            job_type=job_type,
+        )
+
+    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
+
+    client = TestClient(api.app)
+    first = client.post(
+        "/api/uploads",
+        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        "/api/uploads",
+        files={"file": ("meeting-again.mp3", b"abc", "audio/mpeg")},
+    )
+    assert second.status_code == 409
+    assert second.json()["detail"]["existing_job_id"] == "existing-job"
+    items, total = list_recordings(settings=cfg)
+    assert total == 1
+    assert len(sorted(cfg.recordings_root.glob("trs_*"))) == 1
+
+
+def test_reupload_queue_failure_returns_503(tmp_path: Path, monkeypatch):
+    cfg = _cfg(tmp_path)
+    monkeypatch.setattr(api, "_settings", cfg)
+    init_db(cfg)
+
+    def _fake_enqueue(
+        recording_id: str,
+        *,
+        job_type: str = JOB_TYPE_PRECHECK,
+        force_reprocess: bool = False,
+        settings: AppSettings | None = None,
+    ) -> RecordingJob:
+        if force_reprocess:
+            raise RuntimeError("redis down")
+        return RecordingJob(
+            job_id="job-first",
+            recording_id=recording_id,
+            job_type=job_type,
+        )
+
+    monkeypatch.setattr(api, "enqueue_recording_job", _fake_enqueue)
+
+    client = TestClient(api.app)
+    first = client.post(
+        "/api/uploads",
+        files={"file": ("meeting.mp3", b"abc", "audio/mpeg")},
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        "/api/uploads",
+        files={"file": ("meeting-again.mp3", b"abc", "audio/mpeg")},
+    )
+    assert second.status_code == 503
+    assert second.json()["detail"] == "Queue unavailable: redis down"
+    items, total = list_recordings(settings=cfg)
+    assert total == 1
+    assert len(sorted(cfg.recordings_root.glob("trs_*"))) == 1


### PR DESCRIPTION
PR_ID: PR-REUPLOAD-REPROCESS-01
TASK_FILE: tasks/PR-REUPLOAD-REPROCESS-01.md
Branch: pr-reupload-reprocess-01

What changed
- detect duplicate uploads by matching the uploaded raw file against existing recording audio content
- reuse the existing recording id on re-upload and enqueue that recording with `force_reprocess=True`
- log the re-upload event at INFO level before reprocessing starts
- add upload and helper regression tests covering duplicate reuse, conflicts, queue failures, and matcher edge cases
- update `tasks/QUEUE.md` from `DOING` to `DONE`

How verified
- `scripts/ci.sh`

Artifacts
- `artifacts/ci.log`
- `artifacts/pr.patch`

Manual test steps
- upload an audio file and wait for processing to complete
- upload the same file again
- confirm the same recording id is reused and the recording is queued for full reprocessing
- confirm sanitized audio is preserved while downstream stages rerun from scratch

MCP usage
- none